### PR TITLE
🐛 Use explict emoij fonts

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -124,6 +124,7 @@ main.wrap {
 
 	.gitmoji {
 		font-size: 5em;
+		font-family: "Apple Color Emoji", "Segoe UI Emoji", "NotoColorEmoji", "Segoe UI Symbol", "Android Emoji", "EmojiSymbols";
 	}
 
 	&-card {


### PR DESCRIPTION
## Description

For some emoijs fonts provide own black glyhps (like ⬆️ or 🌐). By explict setting the font-family to the different emoijs fonts we get the colorful versions.

![fix-emoij-display](https://cloud.githubusercontent.com/assets/23519/20313455/4be6f696-ab57-11e6-8afb-33652b842ba3.jpg)

## Tests

- [x] All tests passed.

