### PR TITLE
🔧 templates depend on styles; serve depends on both being done

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -30,7 +30,7 @@ const routes = {
 	}
 };
 
-gulp.task('templates', () => {
+gulp.task('templates', ['styles'], () => {
 	return gulp.src([routes.templates.pug, '!' + routes.templates._pug])
 		.pipe(plumber({}))
 		.pipe(pug({
@@ -71,7 +71,7 @@ gulp.task('test', () => {
 		.pipe(gulp.dest(routes.files.html))
 });
 
-gulp.task('serve', () => {
+gulp.task('serve', ['styles', 'templates'], () => {
 	browserSync.init({
 		server: `${baseDirs.dist}`
 	});
@@ -87,7 +87,7 @@ gulp.task('deploy', () => {
 		}))
 });
 
-gulp.task('dev', ['templates', 'styles', 'serve']);
+gulp.task('dev', ['serve']);
 
 gulp.task('default', () => {
 	gulp.start('dev');


### PR DESCRIPTION
## Description

The default gulp task – `dev`, which is just `templates`, `styles`, and `serve` – doesn't work the first time you run it. Since files in the templates reference built styles, `templates` needs to depend on `styles`. Since `serve` serves built files, it needs to wait on both `templates` and `styles` to finish before doing its thing.

## Tests

- [x] All tests passed.

Tangent: I used the gitmoji for "config files" but I'm not sure that's
apt. Do we need a gitmoji for "dev/internal improvements"?