### PR TITLE
Add 👽 to indicate code changes because of external API changes (fixes…

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -227,7 +227,7 @@
 		  "emoji":"👽",
 		  "entity":"&#1F47D;",
 		  "code":":alien:",
-		  "description":"Updating code because of exernal API changes.",
+		  "description":"Updating code due to external API changes.",
 		  "name":"alien"
 		}
 	]

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -222,6 +222,13 @@
 		  "code":":package:",
 		  "description":"Updating compiled files or packages.",
 		  "name":"package"
+		},
+		{
+		  "emoji":"👽",
+		  "entity":"&#1F47D;",
+		  "code":":alien:",
+		  "description":"Updating code because of exernal API changes.",
+		  "name":"alien"
 		}
 	]
 }


### PR DESCRIPTION
Proposing to add 👽  as a new emoji to indicate code changes because of external API changes in external services or dependencies