### PR TITLE
⚡️ improve performance of card hover effect

### DIFF
--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -138,16 +138,33 @@ main.wrap {
 
 	&-card {
 		background-color: $white;
-		margin: 1em 0;
-		flex: 1;
-		transition: all .25s ease-out;
 		border-radius: 4px;
 		box-shadow: 0 1px 2px 0 rgba(168, 182, 191, .6);
-		overflow: hidden;
+		flex: 1;
+		margin: 1em 0;
+		position: relative;
 		text-align: center;
 
 		&:hover {
-			box-shadow: 0 10px 20px 0 rgba(168, 182, 191, .6)
+
+			&::after {
+				opacity: 1;
+			}
+
+		}
+
+		&:after {
+			bottom: 0;
+			box-shadow: 0 10px 20px 0 rgba(168, 182, 191, .6);
+			content: '';
+			left: 0;
+			opacity: 0;
+			position: absolute;
+			right: 0;
+			top: 0;
+			transition: opacity .25s ease-out;
+			will-change: opacity;
+			z-index: -1;
 		}
 	}
 


### PR DESCRIPTION
## Description
Instead of animating `box-shadow` on an element, it is recommended to use a pseudo element and animate it's `opacity`. Properties besides `opacity` and `transform` will trigger some repaint which is more GPU intensive, especially on mobile

## Tests
- [x] All tests passed.

![gitmoji-card-hover](https://cloud.githubusercontent.com/assets/5244986/21404007/7bb8555c-c7bf-11e6-989b-dfbfe7dfaf45.gif)
