### PR TITLE
Open github page in another tab

### DIFF
--- a/src/templates/index.pug
+++ b/src/templates/index.pug
@@ -13,7 +13,7 @@ html
 			include ../images/gitmoji.svg
 			h2 An emoji guide for your commit messages
 			div.header-buttons
-				a.btn.btn-pink(href="https://github.com/carloscuesta/gitmoji/")
+				a.btn.btn-pink(href="https://github.com/carloscuesta/gitmoji/", target="_blank")
 					svg.icon.icon-star
 						use(xlink:href='#icon-star')
 					| GitHub


### PR DESCRIPTION
## Description
I usually get annoyed by this, since I usually want to open the github repositories page but doesn't want the gitmoji page to be closed. So I guess the github page would be better if it's being open in another tab.
<!-- Explanation about your pull request, what changes you've made -->

## Tests

<!-- Ensure that all the tests passed -->
- [ x ] All tests passed.
