### PR TITLE
:lipstick: Change "Removing a dependency" position

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -189,13 +189,6 @@
 			"name":"recycle"
 		},
 		{
-			"emoji":"➖",
-			"entity":"&#10134;",
-			"code":":heavy_minus_sign:",
-			"description":"Removing a dependency.",
-			"name":"heavy-minus-sign"
-		},
-		{
 			"emoji":"🐳",
 			"entity":"&#x1f433;",
 			"code":":whale:",
@@ -208,6 +201,13 @@
 			"code":":heavy_plus_sign:",
 			"description":"Adding a dependency.",
 			"name":"heavy-plus-sign"
+		},
+		{
+			"emoji":"➖",
+			"entity":"&#10134;",
+			"code":":heavy_minus_sign:",
+			"description":"Removing a dependency.",
+			"name":"heavy-minus-sign"
 		},
 		{
 			"emoji":"🔧",


### PR DESCRIPTION
Motivation: IMHO "Removing a dependency" should be in the same line as "Adding a dependency" and also after it.

## Changes preview
<img width="1099" alt="screen shot 2018-02-28 at 14 04 29" src="https://user-images.githubusercontent.com/719641/36789013-6c6282cc-1c90-11e8-920c-2fe8729b84f2.png">
