### PR TITLE
Add emoji for purposefully failing tests for TDD

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -82,7 +82,7 @@
 			"entity":"&#x274C;",
 			"code":":x:",
 			"description":"Causing tests to knowingly fail.",
-			"name":"x"
+			"name":"red-x"
 		},
 		{
 			"emoji":"🔒",

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -78,6 +78,13 @@
 			"name":"white-check-mark"
 		},
 		{
+			"emoji":"❌",
+			"entity":"&#x274C;",
+			"code":":x:",
+			"description":"Causing tests to knowingly fail.",
+			"name":"x"
+		},
+		{
 			"emoji":"🔒",
 			"entity":"&#x1f512;",
 			"code":":lock:",

--- a/src/styles/_includes/_vars.scss
+++ b/src/styles/_includes/_vars.scss
@@ -86,7 +86,7 @@ $gitmojis: (
 	rocket: $rocket,
 	rotating-light: $rotatingLight,
 	sparkles: $sparkles,
-	redX: $redX,
+	red-x: $redX,
 	white-check-mark: $whiteCheckMark,
 	wrench: $wrench,
 	zap: $zap,

--- a/src/styles/_includes/_vars.scss
+++ b/src/styles/_includes/_vars.scss
@@ -23,6 +23,7 @@ $penguin: #fa9a3f;
 $rocket: #00a9f0;
 $rotatingLight: #536DFE;
 $sparkles: #ffe55f;
+$redX: #ff7281;
 $whiteCheckMark: #77e856;
 $wrench: #FFC400;
 $zap: #40C4FF;
@@ -85,6 +86,7 @@ $gitmojis: (
 	rocket: $rocket,
 	rotating-light: $rotatingLight,
 	sparkles: $sparkles,
+	redX: $redX,
 	white-check-mark: $whiteCheckMark,
 	wrench: $wrench,
 	zap: $zap,


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->

When doing Test Driven Development ([TDD](https://en.wikipedia.org/wiki/Test-driven_development)), I typically create one commit that has the tests knowingly fail in our continuous integration environment, followed by another commit that gets the tests passing.

I'll push up a commit that causes tests to fail so the tests can run in the continuous integration environment, and so code reviewers can see the test fail, and then follow that up with a commit that brings the tests back to green.  It follows the idea of red/green/refactor [as mentioned in Wikipedia](https://en.wikipedia.org/wiki/Test-driven_development).

Two example commits:

* ❌ Added failing tests to ensure login link appears
* ✅ Login link now appears
* ♻️ Rename the variable to something clearer


## Tests

<!-- Ensure that all the tests passed -->
- [ ] All tests passed.