### PR TITLE
:pencil2: Fix typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm i -g gitmoji-cli
 
 ## Contributing to gitmoji
 
-Contributing to gitmoji it's a piece of :cake:, read the [contributing guidelines](https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md). You can discuss emojis using the [issues section](https://github.com/carloscuesta/gitmoji/issues/new). To add a new emoji to the list create an issue and send a pull request, see [how to send a pull request and add a gitmoji](https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#how-to-add-a-gitmoji).
+Contributing to gitmoji is a piece of :cake:, read the [contributing guidelines](https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md). You can discuss emojis using the [issues section](https://github.com/carloscuesta/gitmoji/issues/new). To add a new emoji to the list create an issue and send a pull request, see [how to send a pull request and add a gitmoji](https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#how-to-add-a-gitmoji).
 
 ## License
 


### PR DESCRIPTION
Dodgy sentence made me scratch my head for a moment.
Simply replace an erroneous _it's_ --> _is_
