### PR TITLE
🎨 introduce consistent indentation of gitmojis

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -420,18 +420,18 @@
 			"name": "mag"
 		},
 		{
-		  "emoji":"☸️",
-		  "entity":"&#9784;",
-		  "code":":wheel_of_dharma:",
-		  "description":"Work about Kubernetes",
-		  "name":"wheel-of-dharma"
+			"emoji":"☸️",
+			"entity":"&#9784;",
+			"code":":wheel_of_dharma:",
+			"description":"Work about Kubernetes",
+			"name":"wheel-of-dharma"
 		},
 		{
-		  "emoji": "🏷️",
-		  "entity": "&#127991;",
-		  "code": ":label:",
-		  "description": "Adding or updating types (Flow, TypeScript)",
-		  "name": "label"		
+			"emoji": "🏷️",
+			"entity": "&#127991;",
+			"code": ":label:",
+			"description": "Adding or updating types (Flow, TypeScript)",
+			"name": "label"		
 		}
 	]
 }


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->
Last 2 emoji blocks use spaces instead of tabs.
This change fixes them to use tabs like the rest of the gitmojis.json file
## Tests

<!-- Ensure that all the tests passed -->
- [X] All tests passed.
