### PR TITLE
✨ Add 🐙

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -176,6 +176,13 @@
 			"name":"construction-worker"
 		},
 		{
+			"emoji":"🐙",
+			"entity":"&#x1F419;",
+			"code":":octopus:",
+			"description":"Updating task runner tasks, project support utils or tooling.",
+			"name":"octopus"
+		},
+		{
 			"emoji":"📈",
 			"code":":chart_with_upwards_trend:",
 			"description":"Adding analytics or tracking code.",

--- a/src/styles/_includes/_vars.scss
+++ b/src/styles/_includes/_vars.scss
@@ -26,6 +26,7 @@ $sparkles: #ffe55f;
 $whiteCheckMark: #77e856;
 $wrench: #FFC400;
 $zap: #40C4FF;
+$octopus: #ff7281;
 $constructionWorker: #64B5F6;
 $recycle: #77e856;
 $tada: #f74d5f;
@@ -88,6 +89,7 @@ $gitmojis: (
 	white-check-mark: $whiteCheckMark,
 	wrench: $wrench,
 	zap: $zap,
+	octopus: $octopus,
 	construction-worker: $constructionWorker,
 	arrow-up: $arrowUp,
 	arrow-down: $arrowDown,


### PR DESCRIPTION
## Description

Add 🐙 for task runner tasks and project tooling.

Gitmoji is currently missing an alternative for [`chore`](https://stackoverflow.com/questions/26944762/when-to-use-chore-as-type-of-commit-message) from [Conventional Commits](https://www.conventionalcommits.org), that is not related to configuration, docs or CI.

🔧 is overloaded: let it focus on configuration files (static yaml, json, seret injection etc.) and not for all non-trivial project setup.

Octopus tentacles represent task runner taks, or dev meta tools used to
support project development.

Example usages:
- Task runner tasks
- Helper scripts (e.g. shell)
- Git related project setup (husky, lintstaged etc.)
- Testing framework setup

Fixes [#145](https://github.com/carloscuesta/gitmoji/issues/145) and [#130](https://github.com/carloscuesta/gitmoji/issues/130)

## Tests

- [x] All tests passed.