### PR TITLE
👽 Update :pencil: to :memo:

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -45,9 +45,9 @@
 		{
 			"emoji":"📝",
 			"entity":"&#x1f4dd;",
-			"code":":pencil:",
+			"code":":memo:",
 			"description":"Writing docs.",
-			"name":"pencil"
+			"name":"memo"
 		},
 		{
 			"emoji":"🚀",


### PR DESCRIPTION
## Description

Update `:pencil:` to `:memo:`

As you can see, when writing `:pencil:`, the auto complete of GitHub won't suggest the emoji. The code changed to `:memo:`. `:pencil:` can still be used, but to keep this up to date I would recommend that we change that here too.

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
