### PR TITLE
✨ Add 🚩 for changes to feature flags

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -439,6 +439,13 @@
 			"code": ":seedling:",
 			"description": "Adding or updating seed files",
 			"name": "seedling"		
+		},
+		{
+			"emoji": "🚩",
+			"entity": "&#x1F6A9;",
+			"code": ":triangular_flag_on_post:",
+			"description": "Adding, updating, or removing feature flags",
+			"name": "triangular-flag-on-post"
 		}
 	]
 }

--- a/src/styles/_includes/_vars.scss
+++ b/src/styles/_includes/_vars.scss
@@ -70,6 +70,7 @@ $mag: #ffe55f;
 $wheelOfDarma: #40C4FF;
 $label: #cb63e6;
 $seedling: #c5e763;
+$triangularFlagOnPost: #f94e43;
 
 $gitmojis: (
 	art: $art,
@@ -134,5 +135,6 @@ $gitmojis: (
 	mag: $mag,
 	wheel-of-dharma: $wheelOfDarma,
 	label: $label,
-	seedling: $seedling
+	seedling: $seedling,
+	triangular-flag-on-post: $triangularFlagOnPost
 )

--- a/src/styles/_includes/_vars.scss
+++ b/src/styles/_includes/_vars.scss
@@ -136,5 +136,5 @@ $gitmojis: (
 	wheel-of-dharma: $wheelOfDarma,
 	label: $label,
 	seedling: $seedling,
-	triangular-flag-on-post: $triangularFlagOnPost
+	triangular-flag-on-post: $triangularFlagOnPost,
 )

--- a/src/styles/_includes/_vars.scss
+++ b/src/styles/_includes/_vars.scss
@@ -70,7 +70,7 @@ $mag: #ffe55f;
 $wheelOfDarma: #40C4FF;
 $label: #cb63e6;
 $seedling: #c5e763;
-$triangularFlagOnPost: #f94e43;
+$triangularFlagOnPost: #ffce49;
 
 $gitmojis: (
 	art: $art,


### PR DESCRIPTION
This PR addresses https://github.com/carloscuesta/gitmoji/issues/183
(was originally https://github.com/carloscuesta/gitmoji/issues/330) 

## Description

I think an emoji for changes related to feature flags would be swell.

In my day job, I am using 🏁 , though I see you have designated that one for windows changes (🤷‍♂ c'est la vie).

I propose:

Emoji: 🚩
Code: `:triangular_flag_on_post:`
Description: Adding, updating, or removing feature flags
Entity: `&#x1F6A9;`
