### PR TITLE
✨ Copy Gitmoji if click on the code and copy emoji if click on it

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -1024,13 +1024,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🎨"
         >
           <header
             className="art emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":art:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🎨"
             >
               🎨
             </span>
@@ -1038,9 +1039,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :art:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":art:"
+            >
+              <code>
+                :art:
+              </code>
+            </div>
             <p>
               Improving structure / format of the code.
             </p>
@@ -1052,13 +1058,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="⚡️"
         >
           <header
             className="zap emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":zap:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="⚡️"
             >
               ⚡️
             </span>
@@ -1066,9 +1073,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :zap:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":zap:"
+            >
+              <code>
+                :zap:
+              </code>
+            </div>
             <p>
               Improving performance.
             </p>
@@ -1080,13 +1092,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🔥"
         >
           <header
             className="fire emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":fire:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🔥"
             >
               🔥
             </span>
@@ -1094,9 +1107,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :fire:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":fire:"
+            >
+              <code>
+                :fire:
+              </code>
+            </div>
             <p>
               Removing code or files.
             </p>
@@ -1108,13 +1126,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🐛"
         >
           <header
             className="bug emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":bug:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🐛"
             >
               🐛
             </span>
@@ -1122,9 +1141,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :bug:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":bug:"
+            >
+              <code>
+                :bug:
+              </code>
+            </div>
             <p>
               Fixing a bug.
             </p>
@@ -1136,13 +1160,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🚑"
         >
           <header
             className="ambulance emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":ambulance:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🚑"
             >
               🚑
             </span>
@@ -1150,9 +1175,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :ambulance:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":ambulance:"
+            >
+              <code>
+                :ambulance:
+              </code>
+            </div>
             <p>
               Critical hotfix.
             </p>
@@ -1164,13 +1194,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="✨"
         >
           <header
             className="sparkles emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":sparkles:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="✨"
             >
               ✨
             </span>
@@ -1178,9 +1209,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :sparkles:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":sparkles:"
+            >
+              <code>
+                :sparkles:
+              </code>
+            </div>
             <p>
               Introducing new features.
             </p>
@@ -1192,13 +1228,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="📝"
         >
           <header
             className="pencil emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":pencil:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="📝"
             >
               📝
             </span>
@@ -1206,9 +1243,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :pencil:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":pencil:"
+            >
+              <code>
+                :pencil:
+              </code>
+            </div>
             <p>
               Writing docs.
             </p>
@@ -1220,13 +1262,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🚀"
         >
           <header
             className="rocket emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":rocket:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🚀"
             >
               🚀
             </span>
@@ -1234,9 +1277,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :rocket:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":rocket:"
+            >
+              <code>
+                :rocket:
+              </code>
+            </div>
             <p>
               Deploying stuff.
             </p>
@@ -1248,13 +1296,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="💄"
         >
           <header
             className="lipstick emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":lipstick:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="💄"
             >
               💄
             </span>
@@ -1262,9 +1311,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :lipstick:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":lipstick:"
+            >
+              <code>
+                :lipstick:
+              </code>
+            </div>
             <p>
               Updating the UI and style files.
             </p>
@@ -1276,13 +1330,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🎉"
         >
           <header
             className="tada emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":tada:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🎉"
             >
               🎉
             </span>
@@ -1290,9 +1345,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :tada:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":tada:"
+            >
+              <code>
+                :tada:
+              </code>
+            </div>
             <p>
               Initial commit.
             </p>
@@ -1304,13 +1364,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="✅"
         >
           <header
             className="white-check-mark emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":white_check_mark:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="✅"
             >
               ✅
             </span>
@@ -1318,9 +1379,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :white_check_mark:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":white_check_mark:"
+            >
+              <code>
+                :white_check_mark:
+              </code>
+            </div>
             <p>
               Updating tests.
             </p>
@@ -1332,13 +1398,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🔒"
         >
           <header
             className="lock emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":lock:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🔒"
             >
               🔒
             </span>
@@ -1346,9 +1413,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :lock:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":lock:"
+            >
+              <code>
+                :lock:
+              </code>
+            </div>
             <p>
               Fixing security issues.
             </p>
@@ -1360,13 +1432,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🍎"
         >
           <header
             className="apple emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":apple:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🍎"
             >
               🍎
             </span>
@@ -1374,9 +1447,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :apple:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":apple:"
+            >
+              <code>
+                :apple:
+              </code>
+            </div>
             <p>
               Fixing something on macOS.
             </p>
@@ -1388,13 +1466,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🐧"
         >
           <header
             className="penguin emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":penguin:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🐧"
             >
               🐧
             </span>
@@ -1402,9 +1481,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :penguin:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":penguin:"
+            >
+              <code>
+                :penguin:
+              </code>
+            </div>
             <p>
               Fixing something on Linux.
             </p>
@@ -1416,13 +1500,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🏁"
         >
           <header
             className="checkered-flag emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":checkered_flag:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🏁"
             >
               🏁
             </span>
@@ -1430,9 +1515,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :checkered_flag:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":checkered_flag:"
+            >
+              <code>
+                :checkered_flag:
+              </code>
+            </div>
             <p>
               Fixing something on Windows.
             </p>
@@ -1444,13 +1534,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🤖"
         >
           <header
             className="robot emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":robot:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🤖"
             >
               🤖
             </span>
@@ -1458,9 +1549,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :robot:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":robot:"
+            >
+              <code>
+                :robot:
+              </code>
+            </div>
             <p>
               Fixing something on Android.
             </p>
@@ -1472,13 +1568,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🍏"
         >
           <header
             className="green-apple emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":green_apple:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🍏"
             >
               🍏
             </span>
@@ -1486,9 +1583,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :green_apple:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":green_apple:"
+            >
+              <code>
+                :green_apple:
+              </code>
+            </div>
             <p>
               Fixing something on iOS.
             </p>
@@ -1500,13 +1602,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🔖"
         >
           <header
             className="bookmark emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":bookmark:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🔖"
             >
               🔖
             </span>
@@ -1514,9 +1617,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :bookmark:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":bookmark:"
+            >
+              <code>
+                :bookmark:
+              </code>
+            </div>
             <p>
               Releasing / Version tags.
             </p>
@@ -1528,13 +1636,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🚨"
         >
           <header
             className="rotating-light emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":rotating_light:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🚨"
             >
               🚨
             </span>
@@ -1542,9 +1651,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :rotating_light:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":rotating_light:"
+            >
+              <code>
+                :rotating_light:
+              </code>
+            </div>
             <p>
               Removing linter warnings.
             </p>
@@ -1556,13 +1670,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🚧"
         >
           <header
             className="construction emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":construction:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🚧"
             >
               🚧
             </span>
@@ -1570,9 +1685,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :construction:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":construction:"
+            >
+              <code>
+                :construction:
+              </code>
+            </div>
             <p>
               Work in progress.
             </p>
@@ -1584,13 +1704,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="💚"
         >
           <header
             className="green-heart emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":green_heart:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="💚"
             >
               💚
             </span>
@@ -1598,9 +1719,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :green_heart:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":green_heart:"
+            >
+              <code>
+                :green_heart:
+              </code>
+            </div>
             <p>
               Fixing CI Build.
             </p>
@@ -1612,13 +1738,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="⬇️"
         >
           <header
             className="arrow-down emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":arrow_down:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="⬇️"
             >
               ⬇️
             </span>
@@ -1626,9 +1753,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :arrow_down:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":arrow_down:"
+            >
+              <code>
+                :arrow_down:
+              </code>
+            </div>
             <p>
               Downgrading dependencies.
             </p>
@@ -1640,13 +1772,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="⬆️"
         >
           <header
             className="arrow-up emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":arrow_up:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="⬆️"
             >
               ⬆️
             </span>
@@ -1654,9 +1787,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :arrow_up:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":arrow_up:"
+            >
+              <code>
+                :arrow_up:
+              </code>
+            </div>
             <p>
               Upgrading dependencies.
             </p>
@@ -1668,13 +1806,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="📌"
         >
           <header
             className="pushpin emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":pushpin:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="📌"
             >
               📌
             </span>
@@ -1682,9 +1821,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :pushpin:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":pushpin:"
+            >
+              <code>
+                :pushpin:
+              </code>
+            </div>
             <p>
               Pinning dependencies to specific versions.
             </p>
@@ -1696,13 +1840,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="👷"
         >
           <header
             className="construction-worker emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":construction_worker:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="👷"
             >
               👷
             </span>
@@ -1710,9 +1855,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :construction_worker:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":construction_worker:"
+            >
+              <code>
+                :construction_worker:
+              </code>
+            </div>
             <p>
               Adding CI build system.
             </p>
@@ -1724,13 +1874,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="📈"
         >
           <header
             className="chart-with-upwards-trend emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":chart_with_upwards_trend:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="📈"
             >
               📈
             </span>
@@ -1738,9 +1889,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :chart_with_upwards_trend:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":chart_with_upwards_trend:"
+            >
+              <code>
+                :chart_with_upwards_trend:
+              </code>
+            </div>
             <p>
               Adding analytics or tracking code.
             </p>
@@ -1752,13 +1908,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="♻️"
         >
           <header
             className="recycle emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":recycle:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="♻️"
             >
               ♻️
             </span>
@@ -1766,9 +1923,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :recycle:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":recycle:"
+            >
+              <code>
+                :recycle:
+              </code>
+            </div>
             <p>
               Refactoring code.
             </p>
@@ -1780,13 +1942,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🐳"
         >
           <header
             className="whale emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":whale:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🐳"
             >
               🐳
             </span>
@@ -1794,9 +1957,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :whale:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":whale:"
+            >
+              <code>
+                :whale:
+              </code>
+            </div>
             <p>
               Work about Docker.
             </p>
@@ -1808,13 +1976,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="➕"
         >
           <header
             className="heavy-plus-sign emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":heavy_plus_sign:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="➕"
             >
               ➕
             </span>
@@ -1822,9 +1991,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :heavy_plus_sign:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":heavy_plus_sign:"
+            >
+              <code>
+                :heavy_plus_sign:
+              </code>
+            </div>
             <p>
               Adding a dependency.
             </p>
@@ -1836,13 +2010,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="➖"
         >
           <header
             className="heavy-minus-sign emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":heavy_minus_sign:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="➖"
             >
               ➖
             </span>
@@ -1850,9 +2025,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :heavy_minus_sign:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":heavy_minus_sign:"
+            >
+              <code>
+                :heavy_minus_sign:
+              </code>
+            </div>
             <p>
               Removing a dependency.
             </p>
@@ -1864,13 +2044,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🔧"
         >
           <header
             className="wrench emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":wrench:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🔧"
             >
               🔧
             </span>
@@ -1878,9 +2059,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :wrench:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":wrench:"
+            >
+              <code>
+                :wrench:
+              </code>
+            </div>
             <p>
               Changing configuration files.
             </p>
@@ -1892,13 +2078,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🌐"
         >
           <header
             className="globe-with-meridians emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":globe_with_meridians:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🌐"
             >
               🌐
             </span>
@@ -1906,9 +2093,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :globe_with_meridians:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":globe_with_meridians:"
+            >
+              <code>
+                :globe_with_meridians:
+              </code>
+            </div>
             <p>
               Internationalization and localization.
             </p>
@@ -1920,13 +2112,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="✏️"
         >
           <header
             className="pencil emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":pencil2:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="✏️"
             >
               ✏️
             </span>
@@ -1934,9 +2127,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :pencil2:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":pencil2:"
+            >
+              <code>
+                :pencil2:
+              </code>
+            </div>
             <p>
               Fixing typos.
             </p>
@@ -1948,13 +2146,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="💩"
         >
           <header
             className="poop emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":poop:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="💩"
             >
               💩
             </span>
@@ -1962,9 +2161,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :poop:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":poop:"
+            >
+              <code>
+                :poop:
+              </code>
+            </div>
             <p>
               Writing bad code that needs to be improved.
             </p>
@@ -1976,13 +2180,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="⏪"
         >
           <header
             className="rewind emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":rewind:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="⏪"
             >
               ⏪
             </span>
@@ -1990,9 +2195,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :rewind:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":rewind:"
+            >
+              <code>
+                :rewind:
+              </code>
+            </div>
             <p>
               Reverting changes.
             </p>
@@ -2004,13 +2214,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🔀"
         >
           <header
             className="twisted-rightwards-arrows emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":twisted_rightwards_arrows:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🔀"
             >
               🔀
             </span>
@@ -2018,9 +2229,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :twisted_rightwards_arrows:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":twisted_rightwards_arrows:"
+            >
+              <code>
+                :twisted_rightwards_arrows:
+              </code>
+            </div>
             <p>
               Merging branches.
             </p>
@@ -2032,13 +2248,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="📦"
         >
           <header
             className="package emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":package:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="📦"
             >
               📦
             </span>
@@ -2046,9 +2263,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :package:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":package:"
+            >
+              <code>
+                :package:
+              </code>
+            </div>
             <p>
               Updating compiled files or packages.
             </p>
@@ -2060,13 +2282,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="👽"
         >
           <header
             className="alien emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":alien:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="👽"
             >
               👽
             </span>
@@ -2074,9 +2297,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :alien:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":alien:"
+            >
+              <code>
+                :alien:
+              </code>
+            </div>
             <p>
               Updating code due to external API changes.
             </p>
@@ -2088,13 +2316,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🚚"
         >
           <header
             className="truck emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":truck:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🚚"
             >
               🚚
             </span>
@@ -2102,9 +2331,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :truck:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":truck:"
+            >
+              <code>
+                :truck:
+              </code>
+            </div>
             <p>
               Moving or renaming files.
             </p>
@@ -2116,13 +2350,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="📄"
         >
           <header
             className="page-facing-up emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":page_facing_up:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="📄"
             >
               📄
             </span>
@@ -2130,9 +2365,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :page_facing_up:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":page_facing_up:"
+            >
+              <code>
+                :page_facing_up:
+              </code>
+            </div>
             <p>
               Adding or updating license.
             </p>
@@ -2144,13 +2384,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="💥"
         >
           <header
             className="boom emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":boom:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="💥"
             >
               💥
             </span>
@@ -2158,9 +2399,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :boom:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":boom:"
+            >
+              <code>
+                :boom:
+              </code>
+            </div>
             <p>
               Introducing breaking changes.
             </p>
@@ -2172,13 +2418,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🍱"
         >
           <header
             className="bento emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":bento:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🍱"
             >
               🍱
             </span>
@@ -2186,9 +2433,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :bento:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":bento:"
+            >
+              <code>
+                :bento:
+              </code>
+            </div>
             <p>
               Adding or updating assets.
             </p>
@@ -2200,13 +2452,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="👌"
         >
           <header
             className="ok-hand emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":ok_hand:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="👌"
             >
               👌
             </span>
@@ -2214,9 +2467,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :ok_hand:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":ok_hand:"
+            >
+              <code>
+                :ok_hand:
+              </code>
+            </div>
             <p>
               Updating code due to code review changes.
             </p>
@@ -2228,13 +2486,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="♿️"
         >
           <header
             className="wheelchair emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":wheelchair:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="♿️"
             >
               ♿️
             </span>
@@ -2242,9 +2501,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :wheelchair:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":wheelchair:"
+            >
+              <code>
+                :wheelchair:
+              </code>
+            </div>
             <p>
               Improving accessibility.
             </p>
@@ -2256,13 +2520,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="💡"
         >
           <header
             className="bulb emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":bulb:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="💡"
             >
               💡
             </span>
@@ -2270,9 +2535,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :bulb:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":bulb:"
+            >
+              <code>
+                :bulb:
+              </code>
+            </div>
             <p>
               Documenting source code.
             </p>
@@ -2284,13 +2554,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🍻"
         >
           <header
             className="beers emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":beers:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🍻"
             >
               🍻
             </span>
@@ -2298,9 +2569,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :beers:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":beers:"
+            >
+              <code>
+                :beers:
+              </code>
+            </div>
             <p>
               Writing code drunkenly.
             </p>
@@ -2312,13 +2588,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="💬"
         >
           <header
             className="speech-balloon emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":speech_balloon:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="💬"
             >
               💬
             </span>
@@ -2326,9 +2603,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :speech_balloon:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":speech_balloon:"
+            >
+              <code>
+                :speech_balloon:
+              </code>
+            </div>
             <p>
               Updating text and literals.
             </p>
@@ -2340,13 +2622,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🗃"
         >
           <header
             className="card-file-box emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":card_file_box:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🗃"
             >
               🗃
             </span>
@@ -2354,9 +2637,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :card_file_box:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":card_file_box:"
+            >
+              <code>
+                :card_file_box:
+              </code>
+            </div>
             <p>
               Performing database related changes.
             </p>
@@ -2368,13 +2656,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🔊"
         >
           <header
             className="loud-sound emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":loud_sound:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🔊"
             >
               🔊
             </span>
@@ -2382,9 +2671,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :loud_sound:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":loud_sound:"
+            >
+              <code>
+                :loud_sound:
+              </code>
+            </div>
             <p>
               Adding logs.
             </p>
@@ -2396,13 +2690,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🔇"
         >
           <header
             className="mute emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":mute:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🔇"
             >
               🔇
             </span>
@@ -2410,9 +2705,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :mute:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":mute:"
+            >
+              <code>
+                :mute:
+              </code>
+            </div>
             <p>
               Removing logs.
             </p>
@@ -2424,13 +2724,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="👥"
         >
           <header
             className="busts-in-silhouette emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":busts_in_silhouette:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="👥"
             >
               👥
             </span>
@@ -2438,9 +2739,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :busts_in_silhouette:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":busts_in_silhouette:"
+            >
+              <code>
+                :busts_in_silhouette:
+              </code>
+            </div>
             <p>
               Adding contributor(s).
             </p>
@@ -2452,13 +2758,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🚸"
         >
           <header
             className="children-crossing emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":children_crossing:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🚸"
             >
               🚸
             </span>
@@ -2466,9 +2773,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :children_crossing:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":children_crossing:"
+            >
+              <code>
+                :children_crossing:
+              </code>
+            </div>
             <p>
               Improving user experience / usability.
             </p>
@@ -2480,13 +2792,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🏗"
         >
           <header
             className="building-construction emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":building_construction:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🏗"
             >
               🏗
             </span>
@@ -2494,9 +2807,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :building_construction:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":building_construction:"
+            >
+              <code>
+                :building_construction:
+              </code>
+            </div>
             <p>
               Making architectural changes.
             </p>
@@ -2508,13 +2826,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="📱"
         >
           <header
             className="iphone emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":iphone:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="📱"
             >
               📱
             </span>
@@ -2522,9 +2841,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :iphone:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":iphone:"
+            >
+              <code>
+                :iphone:
+              </code>
+            </div>
             <p>
               Working on responsive design.
             </p>
@@ -2536,13 +2860,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🤡"
         >
           <header
             className="clown-face emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":clown_face:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🤡"
             >
               🤡
             </span>
@@ -2550,9 +2875,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :clown_face:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":clown_face:"
+            >
+              <code>
+                :clown_face:
+              </code>
+            </div>
             <p>
               Mocking things.
             </p>
@@ -2564,13 +2894,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🥚"
         >
           <header
             className="egg emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":egg:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🥚"
             >
               🥚
             </span>
@@ -2578,9 +2909,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :egg:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":egg:"
+            >
+              <code>
+                :egg:
+              </code>
+            </div>
             <p>
               Adding an easter egg.
             </p>
@@ -2592,13 +2928,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🙈"
         >
           <header
             className="see-no-evil emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":see_no_evil:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🙈"
             >
               🙈
             </span>
@@ -2606,9 +2943,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :see_no_evil:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":see_no_evil:"
+            >
+              <code>
+                :see_no_evil:
+              </code>
+            </div>
             <p>
               Adding or updating a .gitignore file
             </p>
@@ -2620,13 +2962,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="📸"
         >
           <header
             className="camera-flash emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":camera_flash:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="📸"
             >
               📸
             </span>
@@ -2634,9 +2977,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :camera_flash:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":camera_flash:"
+            >
+              <code>
+                :camera_flash:
+              </code>
+            </div>
             <p>
               Adding or updating snapshots
             </p>
@@ -2648,13 +2996,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="⚗"
         >
           <header
             className="alembic emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":alembic:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="⚗"
             >
               ⚗
             </span>
@@ -2662,9 +3011,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :alembic:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":alembic:"
+            >
+              <code>
+                :alembic:
+              </code>
+            </div>
             <p>
               Experimenting new things
             </p>
@@ -2676,13 +3030,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🔍"
         >
           <header
             className="mag emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":mag:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🔍"
             >
               🔍
             </span>
@@ -2690,9 +3045,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :mag:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":mag:"
+            >
+              <code>
+                :mag:
+              </code>
+            </div>
             <p>
               Improving SEO
             </p>
@@ -2704,13 +3064,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="☸️"
         >
           <header
             className="wheel-of-dharma emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":wheel_of_dharma:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="☸️"
             >
               ☸️
             </span>
@@ -2718,9 +3079,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :wheel_of_dharma:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":wheel_of_dharma:"
+            >
+              <code>
+                :wheel_of_dharma:
+              </code>
+            </div>
             <p>
               Work about Kubernetes
             </p>
@@ -2732,13 +3098,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🏷️"
         >
           <header
             className="label emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":label:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🏷️"
             >
               🏷️
             </span>
@@ -2746,9 +3113,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :label:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":label:"
+            >
+              <code>
+                :label:
+              </code>
+            </div>
             <p>
               Adding or updating types (Flow, TypeScript)
             </p>
@@ -2760,13 +3132,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🌱"
         >
           <header
             className="seedling emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":seedling:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🌱"
             >
               🌱
             </span>
@@ -2774,9 +3147,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :seedling:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":seedling:"
+            >
+              <code>
+                :seedling:
+              </code>
+            </div>
             <p>
               Adding or updating seed files
             </p>
@@ -2788,13 +3166,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🚩"
         >
           <header
             className="triangular-flag-on-post emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":triangular_flag_on_post:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🚩"
             >
               🚩
             </span>
@@ -2802,9 +3181,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :triangular_flag_on_post:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":triangular_flag_on_post:"
+            >
+              <code>
+                :triangular_flag_on_post:
+              </code>
+            </div>
             <p>
               Adding, updating, or removing feature flags
             </p>
@@ -2816,13 +3200,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🥅"
         >
           <header
             className="goal-net emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":goal_net:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🥅"
             >
               🥅
             </span>
@@ -2830,9 +3215,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :goal_net:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":goal_net:"
+            >
+              <code>
+                :goal_net:
+              </code>
+            </div>
             <p>
               Catching errors
             </p>
@@ -2844,13 +3234,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="💫"
         >
           <header
             className="animation emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":dizzy:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="💫"
             >
               💫
             </span>
@@ -2858,9 +3249,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :dizzy:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":dizzy:"
+            >
+              <code>
+                :dizzy:
+              </code>
+            </div>
             <p>
               Adding or updating animations and transitions
             </p>
@@ -2872,13 +3268,14 @@ Array [
       >
         <div
           className="emoji-card"
+          data-clipboard-text="🗑"
         >
           <header
             className="wastebasket emoji-header"
           >
             <span
-              className="emoji-icon gitmoji"
-              data-clipboard-text=":wastebasket:"
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🗑"
             >
               🗑
             </span>
@@ -2886,9 +3283,14 @@ Array [
           <div
             className="emoji-info"
           >
-            <code>
-              :wastebasket:
-            </code>
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":wastebasket:"
+            >
+              <code>
+                :wastebasket:
+              </code>
+            </div>
             <p>
               Deprecating code that needs to be cleaned up.
             </p>

--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -1024,7 +1024,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🎨"
         >
           <header
             className="art emoji-header"
@@ -1058,7 +1057,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="⚡️"
         >
           <header
             className="zap emoji-header"
@@ -1092,7 +1090,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🔥"
         >
           <header
             className="fire emoji-header"
@@ -1126,7 +1123,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🐛"
         >
           <header
             className="bug emoji-header"
@@ -1160,7 +1156,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🚑"
         >
           <header
             className="ambulance emoji-header"
@@ -1194,7 +1189,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="✨"
         >
           <header
             className="sparkles emoji-header"
@@ -1228,7 +1222,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="📝"
         >
           <header
             className="pencil emoji-header"
@@ -1262,7 +1255,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🚀"
         >
           <header
             className="rocket emoji-header"
@@ -1296,7 +1288,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="💄"
         >
           <header
             className="lipstick emoji-header"
@@ -1330,7 +1321,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🎉"
         >
           <header
             className="tada emoji-header"
@@ -1364,7 +1354,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="✅"
         >
           <header
             className="white-check-mark emoji-header"
@@ -1398,7 +1387,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🔒"
         >
           <header
             className="lock emoji-header"
@@ -1432,7 +1420,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🍎"
         >
           <header
             className="apple emoji-header"
@@ -1466,7 +1453,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🐧"
         >
           <header
             className="penguin emoji-header"
@@ -1500,7 +1486,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🏁"
         >
           <header
             className="checkered-flag emoji-header"
@@ -1534,7 +1519,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🤖"
         >
           <header
             className="robot emoji-header"
@@ -1568,7 +1552,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🍏"
         >
           <header
             className="green-apple emoji-header"
@@ -1602,7 +1585,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🔖"
         >
           <header
             className="bookmark emoji-header"
@@ -1636,7 +1618,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🚨"
         >
           <header
             className="rotating-light emoji-header"
@@ -1670,7 +1651,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🚧"
         >
           <header
             className="construction emoji-header"
@@ -1704,7 +1684,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="💚"
         >
           <header
             className="green-heart emoji-header"
@@ -1738,7 +1717,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="⬇️"
         >
           <header
             className="arrow-down emoji-header"
@@ -1772,7 +1750,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="⬆️"
         >
           <header
             className="arrow-up emoji-header"
@@ -1806,7 +1783,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="📌"
         >
           <header
             className="pushpin emoji-header"
@@ -1840,7 +1816,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="👷"
         >
           <header
             className="construction-worker emoji-header"
@@ -1874,7 +1849,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="📈"
         >
           <header
             className="chart-with-upwards-trend emoji-header"
@@ -1908,7 +1882,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="♻️"
         >
           <header
             className="recycle emoji-header"
@@ -1942,7 +1915,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🐳"
         >
           <header
             className="whale emoji-header"
@@ -1976,7 +1948,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="➕"
         >
           <header
             className="heavy-plus-sign emoji-header"
@@ -2010,7 +1981,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="➖"
         >
           <header
             className="heavy-minus-sign emoji-header"
@@ -2044,7 +2014,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🔧"
         >
           <header
             className="wrench emoji-header"
@@ -2078,7 +2047,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🌐"
         >
           <header
             className="globe-with-meridians emoji-header"
@@ -2112,7 +2080,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="✏️"
         >
           <header
             className="pencil emoji-header"
@@ -2146,7 +2113,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="💩"
         >
           <header
             className="poop emoji-header"
@@ -2180,7 +2146,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="⏪"
         >
           <header
             className="rewind emoji-header"
@@ -2214,7 +2179,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🔀"
         >
           <header
             className="twisted-rightwards-arrows emoji-header"
@@ -2248,7 +2212,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="📦"
         >
           <header
             className="package emoji-header"
@@ -2282,7 +2245,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="👽"
         >
           <header
             className="alien emoji-header"
@@ -2316,7 +2278,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🚚"
         >
           <header
             className="truck emoji-header"
@@ -2350,7 +2311,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="📄"
         >
           <header
             className="page-facing-up emoji-header"
@@ -2384,7 +2344,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="💥"
         >
           <header
             className="boom emoji-header"
@@ -2418,7 +2377,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🍱"
         >
           <header
             className="bento emoji-header"
@@ -2452,7 +2410,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="👌"
         >
           <header
             className="ok-hand emoji-header"
@@ -2486,7 +2443,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="♿️"
         >
           <header
             className="wheelchair emoji-header"
@@ -2520,7 +2476,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="💡"
         >
           <header
             className="bulb emoji-header"
@@ -2554,7 +2509,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🍻"
         >
           <header
             className="beers emoji-header"
@@ -2588,7 +2542,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="💬"
         >
           <header
             className="speech-balloon emoji-header"
@@ -2622,7 +2575,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🗃"
         >
           <header
             className="card-file-box emoji-header"
@@ -2656,7 +2608,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🔊"
         >
           <header
             className="loud-sound emoji-header"
@@ -2690,7 +2641,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🔇"
         >
           <header
             className="mute emoji-header"
@@ -2724,7 +2674,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="👥"
         >
           <header
             className="busts-in-silhouette emoji-header"
@@ -2758,7 +2707,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🚸"
         >
           <header
             className="children-crossing emoji-header"
@@ -2792,7 +2740,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🏗"
         >
           <header
             className="building-construction emoji-header"
@@ -2826,7 +2773,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="📱"
         >
           <header
             className="iphone emoji-header"
@@ -2860,7 +2806,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🤡"
         >
           <header
             className="clown-face emoji-header"
@@ -2894,7 +2839,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🥚"
         >
           <header
             className="egg emoji-header"
@@ -2928,7 +2872,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🙈"
         >
           <header
             className="see-no-evil emoji-header"
@@ -2962,7 +2905,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="📸"
         >
           <header
             className="camera-flash emoji-header"
@@ -2996,7 +2938,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="⚗"
         >
           <header
             className="alembic emoji-header"
@@ -3030,7 +2971,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🔍"
         >
           <header
             className="mag emoji-header"
@@ -3064,7 +3004,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="☸️"
         >
           <header
             className="wheel-of-dharma emoji-header"
@@ -3098,7 +3037,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🏷️"
         >
           <header
             className="label emoji-header"
@@ -3132,7 +3070,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🌱"
         >
           <header
             className="seedling emoji-header"
@@ -3166,7 +3103,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🚩"
         >
           <header
             className="triangular-flag-on-post emoji-header"
@@ -3200,7 +3136,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🥅"
         >
           <header
             className="goal-net emoji-header"
@@ -3234,7 +3169,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="💫"
         >
           <header
             className="animation emoji-header"
@@ -3268,7 +3202,6 @@ Array [
       >
         <div
           className="emoji-card"
-          data-clipboard-text="🗑"
         >
           <header
             className="wastebasket emoji-header"

--- a/src/components/GitmojiList/Gitmoji/index.js
+++ b/src/components/GitmojiList/Gitmoji/index.js
@@ -9,14 +9,19 @@ type Props = {
 
 const Gitmoji = (props: Props) => (
   <article className="emoji col-xs-12 col-sm-6 col-md-3">
-    <div className="emoji-card">
+    <div className="emoji-card" data-clipboard-text={props.emoji}>
       <header className={`${props.name} emoji-header`}>
-        <span className="emoji-icon gitmoji" data-clipboard-text={props.code}>
+        <span
+          className="emoji-icon gitmoji-emoji"
+          data-clipboard-text={props.emoji}
+        >
           {props.emoji}
         </span>
       </header>
       <div className="emoji-info">
-        <code>{props.code}</code>
+        <div className="gitmoji-code" data-clipboard-text={props.code}>
+          <code>{props.code}</code>
+        </div>
         <p>{props.description}</p>
       </div>
     </div>

--- a/src/components/GitmojiList/Gitmoji/index.js
+++ b/src/components/GitmojiList/Gitmoji/index.js
@@ -9,7 +9,7 @@ type Props = {
 
 const Gitmoji = (props: Props) => (
   <article className="emoji col-xs-12 col-sm-6 col-md-3">
-    <div className="emoji-card" data-clipboard-text={props.emoji}>
+    <div className="emoji-card">
       <header className={`${props.name} emoji-header`}>
         <span
           className="emoji-icon gitmoji-emoji"

--- a/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.js.snap
+++ b/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.js.snap
@@ -10,7 +10,6 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
-      data-clipboard-text="🎨"
     >
       <header
         className="art emoji-header"
@@ -44,7 +43,6 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
-      data-clipboard-text="⚡️"
     >
       <header
         className="zap emoji-header"
@@ -78,7 +76,6 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
-      data-clipboard-text="🔥"
     >
       <header
         className="fire emoji-header"
@@ -112,7 +109,6 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
-      data-clipboard-text="🐛"
     >
       <header
         className="bug emoji-header"
@@ -146,7 +142,6 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
-      data-clipboard-text="🚑"
     >
       <header
         className="ambulance emoji-header"
@@ -180,7 +175,6 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
-      data-clipboard-text="✨"
     >
       <header
         className="sparkles emoji-header"

--- a/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.js.snap
+++ b/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.js.snap
@@ -10,13 +10,14 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
+      data-clipboard-text="🎨"
     >
       <header
         className="art emoji-header"
       >
         <span
-          className="emoji-icon gitmoji"
-          data-clipboard-text=":art:"
+          className="emoji-icon gitmoji-emoji"
+          data-clipboard-text="🎨"
         >
           🎨
         </span>
@@ -24,9 +25,14 @@ exports[`GitmojiList should render the component 1`] = `
       <div
         className="emoji-info"
       >
-        <code>
-          :art:
-        </code>
+        <div
+          className="gitmoji-code"
+          data-clipboard-text=":art:"
+        >
+          <code>
+            :art:
+          </code>
+        </div>
         <p>
           Improving structure / format of the code.
         </p>
@@ -38,13 +44,14 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
+      data-clipboard-text="⚡️"
     >
       <header
         className="zap emoji-header"
       >
         <span
-          className="emoji-icon gitmoji"
-          data-clipboard-text=":zap:"
+          className="emoji-icon gitmoji-emoji"
+          data-clipboard-text="⚡️"
         >
           ⚡️
         </span>
@@ -52,9 +59,14 @@ exports[`GitmojiList should render the component 1`] = `
       <div
         className="emoji-info"
       >
-        <code>
-          :zap:
-        </code>
+        <div
+          className="gitmoji-code"
+          data-clipboard-text=":zap:"
+        >
+          <code>
+            :zap:
+          </code>
+        </div>
         <p>
           Improving performance.
         </p>
@@ -66,13 +78,14 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
+      data-clipboard-text="🔥"
     >
       <header
         className="fire emoji-header"
       >
         <span
-          className="emoji-icon gitmoji"
-          data-clipboard-text=":fire:"
+          className="emoji-icon gitmoji-emoji"
+          data-clipboard-text="🔥"
         >
           🔥
         </span>
@@ -80,9 +93,14 @@ exports[`GitmojiList should render the component 1`] = `
       <div
         className="emoji-info"
       >
-        <code>
-          :fire:
-        </code>
+        <div
+          className="gitmoji-code"
+          data-clipboard-text=":fire:"
+        >
+          <code>
+            :fire:
+          </code>
+        </div>
         <p>
           Removing code or files.
         </p>
@@ -94,13 +112,14 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
+      data-clipboard-text="🐛"
     >
       <header
         className="bug emoji-header"
       >
         <span
-          className="emoji-icon gitmoji"
-          data-clipboard-text=":bug:"
+          className="emoji-icon gitmoji-emoji"
+          data-clipboard-text="🐛"
         >
           🐛
         </span>
@@ -108,9 +127,14 @@ exports[`GitmojiList should render the component 1`] = `
       <div
         className="emoji-info"
       >
-        <code>
-          :bug:
-        </code>
+        <div
+          className="gitmoji-code"
+          data-clipboard-text=":bug:"
+        >
+          <code>
+            :bug:
+          </code>
+        </div>
         <p>
           Fixing a bug.
         </p>
@@ -122,13 +146,14 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
+      data-clipboard-text="🚑"
     >
       <header
         className="ambulance emoji-header"
       >
         <span
-          className="emoji-icon gitmoji"
-          data-clipboard-text=":ambulance:"
+          className="emoji-icon gitmoji-emoji"
+          data-clipboard-text="🚑"
         >
           🚑
         </span>
@@ -136,9 +161,14 @@ exports[`GitmojiList should render the component 1`] = `
       <div
         className="emoji-info"
       >
-        <code>
-          :ambulance:
-        </code>
+        <div
+          className="gitmoji-code"
+          data-clipboard-text=":ambulance:"
+        >
+          <code>
+            :ambulance:
+          </code>
+        </div>
         <p>
           Critical hotfix.
         </p>
@@ -150,13 +180,14 @@ exports[`GitmojiList should render the component 1`] = `
   >
     <div
       className="emoji-card"
+      data-clipboard-text="✨"
     >
       <header
         className="sparkles emoji-header"
       >
         <span
-          className="emoji-icon gitmoji"
-          data-clipboard-text=":sparkles:"
+          className="emoji-icon gitmoji-emoji"
+          data-clipboard-text="✨"
         >
           ✨
         </span>
@@ -164,9 +195,14 @@ exports[`GitmojiList should render the component 1`] = `
       <div
         className="emoji-info"
       >
-        <code>
-          :sparkles:
-        </code>
+        <div
+          className="gitmoji-code"
+          data-clipboard-text=":sparkles:"
+        >
+          <code>
+            :sparkles:
+          </code>
+        </div>
         <p>
           Introducing new features.
         </p>

--- a/src/components/GitmojiList/index.js
+++ b/src/components/GitmojiList/index.js
@@ -15,13 +15,27 @@ type Props = {
 
 const GitmojiList = (props: Props) => {
   React.useEffect(() => {
-    const clipboard = new Clipboard('.gitmoji')
+    const clipboard = new Clipboard('.gitmoji-code')
+    const clipboardTest = new Clipboard('.gitmoji-emoji')
 
-    clipboard.on('success', function() {
+    clipboard.on('success', function(e) {
       window.ga('send', 'event', 'Gitmoji', 'Copy to Clipboard')
 
       var notification = new window.NotificationFx({
-        message: '<p>Hey! Gitmoji copied to the clipboard 😜</p>',
+        message: `<p>Hey! Gitmoji <span class="gitmoji-code">${e.text}</span> copied to the clipboard 😜</p>`,
+        layout: 'growl',
+        effect: 'scale',
+        type: 'notice'
+      })
+
+      notification.show()
+    })
+
+    clipboardTest.on('success', function(e) {
+      window.ga('send', 'event', 'Gitmoji', 'Copy to Clipboard')
+
+      var notification = new window.NotificationFx({
+        message: `<p>Hey! Gitmoji emoji ${e.text} copied to the clipboard 😜</p>`,
         layout: 'growl',
         effect: 'scale',
         type: 'notice'

--- a/src/components/GitmojiList/index.js
+++ b/src/components/GitmojiList/index.js
@@ -15,27 +15,20 @@ type Props = {
 
 const GitmojiList = (props: Props) => {
   React.useEffect(() => {
-    const clipboard = new Clipboard('.gitmoji-code')
-    const clipboardTest = new Clipboard('.gitmoji-emoji')
+    const clipboard = new Clipboard('.gitmoji-code, .gitmoji-emoji')
 
     clipboard.on('success', function(e) {
       window.ga('send', 'event', 'Gitmoji', 'Copy to Clipboard')
 
-      var notification = new window.NotificationFx({
-        message: `<p>Hey! Gitmoji <span class="gitmoji-code">${e.text}</span> copied to the clipboard 😜</p>`,
-        layout: 'growl',
-        effect: 'scale',
-        type: 'notice'
-      })
+      const elementClasses = e.trigger.classList
+      let notificationMessage = `<p>Hey! Gitmoji <span class="gitmoji-code">${e.text}</span> copied to the clipboard 😜</p>`
 
-      notification.show()
-    })
-
-    clipboardTest.on('success', function(e) {
-      window.ga('send', 'event', 'Gitmoji', 'Copy to Clipboard')
+      if (elementClasses.contains('gitmoji-emoji')) {
+        notificationMessage = `<p>Hey! Gitmoji emoji ${e.text} copied to the clipboard 😜</p>`
+      }
 
       var notification = new window.NotificationFx({
-        message: `<p>Hey! Gitmoji emoji ${e.text} copied to the clipboard 😜</p>`,
+        message: notificationMessage,
         layout: 'growl',
         effect: 'scale',
         type: 'notice'

--- a/src/styles/_includes/_notifications.scss
+++ b/src/styles/_includes/_notifications.scss
@@ -28,6 +28,13 @@
     margin: 0;
   }
 
+  .gitmoji-code {
+    padding: 0 4px;
+    border-radius: 4px;
+    background-color: rgba($black, 0.7);
+    color: $white;
+  }
+
   &.ns-show,
   &.ns-visible {
     pointer-events: auto;
@@ -84,7 +91,7 @@
 .ns-growl {
   top: 30px;
   left: 30px;
-  max-width: 300px;
+  max-width: 350px;
   border-radius: 5px;
 }
 
@@ -135,6 +142,7 @@
     opacity: 0;
     -webkit-transform: translate3d(0, 40px, 0) scale3d(0.1, 0.6, 1);
   }
+
   100% {
     opacity: 1;
     -webkit-transform: translate3d(0, 0, 0) scale3d(1, 1, 1);
@@ -147,6 +155,7 @@
     -webkit-transform: translate3d(0, 40px, 0) scale3d(0.1, 0.6, 1);
     transform: translate3d(0, 40px, 0) scale3d(0.1, 0.6, 1);
   }
+
   100% {
     opacity: 1;
     -webkit-transform: translate3d(0, 0, 0) scale3d(1, 1, 1);

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -130,10 +130,29 @@ main.wrap {
   box-sizing: border-box;
 
   .gitmoji {
-    font-size: 5em;
-    cursor: pointer;
-    font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji',
-      'Segoe UI Symbol', 'Android Emoji', 'EmojiSymbols';
+    &-emoji {
+      display: inline-block;
+      font-size: 5em;
+      cursor: pointer;
+      font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji',
+        'Segoe UI Symbol', 'Android Emoji', 'EmojiSymbols';
+
+      &:hover {
+        animation-name: bounce;
+        animation-duration: 0.5s;
+      }
+    }
+
+    &-code {
+      border-radius: 4px;
+      padding-bottom: 4px;
+      transition-duration: 0.3s;
+      border-bottom: solid 2px rgba(0, 0, 0, 0);
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
   }
 
   &-card {
@@ -257,6 +276,13 @@ main.wrap {
 @each $gitmoji, $color in ($gitmojis) {
   .#{$gitmoji} {
     background-color: $color;
+
+    & ~ .emoji-info .gitmoji-code {
+      &:hover {
+        background-color: rgba($color, 0.3);
+        box-shadow: 0 4px rgba($color, 0.6);
+      }
+    }
   }
 }
 
@@ -265,19 +291,54 @@ main.wrap {
   100% {
     color: #7ccdea;
   }
+
   16% {
     color: #0074d9;
   }
+
   32% {
     color: #2ecc40;
   }
+
   48% {
     color: #ffdc00;
   }
+
   64% {
     color: #b10dc9;
   }
+
   80% {
     color: #ff4136;
+  }
+}
+
+/*
+  This code has been obtained from:
+  https://github.com/daneden/animate.css/blob/master/source/attention_seekers/bounce.css
+*/
+@keyframes bounce {
+  from,
+  20%,
+  53%,
+  80%,
+  to {
+    animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+    transform: translate3d(0, 0, 0);
+  }
+
+  40%,
+  43% {
+    animation-timing-function: cubic-bezier(0.755, 0.05, 0.855, 0.06);
+    transform: translate3d(0, -9px, 0);
+  }
+
+  70% {
+    animation-timing-function: cubic-bezier(0.755, 0.05, 0.855, 0.06);
+    transform: translate3d(0, -5px, 0);
+  }
+
+  90% {
+    transform: translate3d(0, -2px, 0);
   }
 }

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -145,7 +145,6 @@ main.wrap {
 
     &-code {
       border-radius: 4px;
-      padding-bottom: 4px;
       transition-duration: 0.3s;
       border-bottom: solid 2px rgba(0, 0, 0, 0);
 

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -147,10 +147,7 @@ main.wrap {
       border-radius: 4px;
       transition-duration: 0.3s;
       border-bottom: solid 2px rgba(0, 0, 0, 0);
-
-      &:hover {
-        cursor: pointer;
-      }
+      cursor: pointer;
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->
Implementation of issue #419 

- User is able to click on the emoji to get the emoji copied in clipboard and he also can click on the gitmoji 'code' that produce the current behaviour (copy gitmoji)
- Gitmoji 'code' is wrapped in a clickable area wich has the same bg-color as the `emoji-header`
- Gitmoji 'emoji' is animated on hover to enforce UX (catchy animation to say that this area is clickable too)
- The alert message specifying what you have copied. It can be both:
  - `Hey! Gitmoji emoji 🎨 copied to the clipboard 😜`
  - `Hey! Gitmoji :art: copied to the clipboard 😜`

[![Feature demo][1]][1]


  [1]: https://i.stack.imgur.com/Jtorg.gif

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
