### PR TITLE
Update ok hand to eyes for code review changes 👀

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -295,11 +295,11 @@
       "name": "bento"
     },
     {
-      "emoji": "👌",
-      "entity": "&#x1f44c;",
-      "code": ":ok_hand:",
+      "emoji": "👀",
+      "entity": "&#128064;",
+      "code": ":eyes:",
       "description": "Updating code due to code review changes.",
-      "name": "ok-hand"
+      "name": "eyes"
     },
     {
       "emoji": "♿️",


### PR DESCRIPTION
Since the ok hand symbol has been co-opted by white nationalists, it might be more inclusive to change that emoji for code review changes.

## Description

Change the ok hand emoji to eyes for code review changes.

