### PR TITLE
💬 Update 📸 code and name

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -2709,7 +2709,7 @@ Array [
           className="emoji-card"
         >
           <header
-            className="camera-flash emoji-header"
+            className="camera-with-flash emoji-header"
           >
             <span
               className="emoji-icon gitmoji-emoji"
@@ -2723,10 +2723,10 @@ Array [
           >
             <div
               className="gitmoji-code"
-              data-clipboard-text=":camera_flash:"
+              data-clipboard-text=":camera_with_flash:"
             >
               <code>
-                :camera_flash:
+                :camera_with_flash:
               </code>
             </div>
             <p>

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -360,9 +360,9 @@
     {
       "emoji": "📸",
       "entity": "&#128248;",
-      "code": ":camera_flash:",
+      "code": ":camera_with_flash:",
       "description": "Add or update snapshots",
-      "name": "camera-flash"
+      "name": "camera-with-flash"
     },
     {
       "emoji": "⚗",

--- a/src/styles/_includes/_vars.scss
+++ b/src/styles/_includes/_vars.scss
@@ -23,7 +23,7 @@ $gitmojis: (
   building-construction: #ffe55f,
   bulb: #ffce49,
   busts-in-silhouette: #ffce49,
-  camera-flash: #00a9f0,
+  camera-with-flash: #00a9f0,
   card-file-box: #c5e763,
   chart-with-upwards-trend: #cedae6,
   children-crossing: #ffce49,


### PR DESCRIPTION
## Description
According to the [emojipedia](https://emojipedia.org/camera-with-flash), [emojiterra](https://emojiterra.com/camera-with-flash) and [emojis.wiki](https://emojis.wiki/camera-with-flash/), the shortcode for the 📸  should be `:camera_with_flash:`.

I have no clue why GitHub decided to use `:camera_flash:` when `:camera_with_flash:` is the correct way as being used by i.e. Slack, WhatsApp, and GitLab.

## Tests
- [x] All tests passed.
