### PR TITLE
🔧 Move site to Vercel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,6 @@ script:
   - yarn run flow
   - yarn run test
   - yarn run validate:gitmojis
-before_deploy:
-  - yarn run build
-  - yarn run export
-deploy:
-  provider: pages
-  local-dir: out
-  skip-cleanup: true
-  github-token: $GITHUB_PAGES_DEPLOY_TOKEN
-  keep-history: true
-  target-branch: gh-pages
-  fqdn: gitmoji.carloscuesta.me
-  on:
-    branch: master
 notifications:
   slack:
     secure: oTOAM8T5Qo3sZ+oB54OfwRA/F1IFrt3J2TFGobYqSk5GZFBJZ/idlSFmKsMCfqVYTMzNhWlYj4H+isdAVzVh/TgbFKY88/GcbtNG8QYCJcFaWOanIp38XQ2RiSImt5T4aMquq/pFj1cE+CNTIWRoieDteukq/bIT3Z1I8hpz5QCSxAFr0suPSwCv1MLXR0ytVldF16eeTVQ0BR8l4L/K5IBt6ZfnpkebZMS0Q3MCobUosAgE1hIHFYxdXYugfmnG0cO2wtLvXwQWQ6VoRGJdc0iAL4CFJxKORX43Y//T0P5e0dBiGfek7QP5gJk+8qeFd5D2O34pB/POUy2vtFvBKTSsgOhz94fmS5v5M4X60oHsNWYt8AUU9CMicYQ2U2pbYAlttTGN3tguC/usdJRS9kWdn6MbI8T6cjk2BCyriFXXXumLEINiHYexcb0PdAm2Lwc//5QSxCdFPGr5UfdhAfwpNOy21QhvcioGUJbtLuyEMP+F9+ZMYWypfacD507yqtr5Z+rtInp4qOuKwZFSir7IzTBbuEUuxJLagbwUTbT302sYarOPvpAjgzPbPWFuUVigZ1y/SPbdObbolOh2yGEfYwIIIPT8ijKPN+sgDFOr0TJ1ZkB59Kb5zW/pDAykWqf2kmLHCFQGcatPzg1ROrrR5CH6/+LVQKhxUEaGLaE=

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "main": "src/data/gitmojis.json",
   "files": ["src/data/gitmojis.json"],
   "scripts": {
-    "build": "next build",
+    "build": "next build && next export",
     "dev": "next dev",
-    "export": "next export && touch out/.nojekyll",
     "flow": "flow",
     "lint": "prettier --check src/**/*.{js,json,scss}",
     "start": "next start",


### PR DESCRIPTION
## Description

Instead of using `github-pages` for hosting the site. We're moving it to vercel,
to have Deploy Previews for the PRs.

This fixes #481

Once this is merged I should update the DNS of `gitmoji.carloscuesta.me` to point to vercel