### PR TITLE
✨ Enhancement 548: Add 🌌 for whitespace only commits

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -1752,6 +1752,39 @@ Array [
           className="emoji-card"
         >
           <header
+            className="milky-way emoji-header"
+          >
+            <span
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🌌"
+            >
+              🌌
+            </span>
+          </header>
+          <div
+            className="emoji-info"
+          >
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":milky_way:"
+            >
+              <code>
+                :milky_way:
+              </code>
+            </div>
+            <p>
+              Modify whitespace.
+            </p>
+          </div>
+        </div>
+      </article>
+      <article
+        className="emoji col-xs-12 col-sm-6 col-md-3"
+      >
+        <div
+          className="emoji-card"
+        >
+          <header
             className="heavy-plus-sign emoji-header"
           >
             <span

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -155,6 +155,13 @@
       "name": "recycle"
     },
     {
+      "emoji": "🌌",
+      "entity": "&#x1F30C;",
+      "code": ":milky_way:",
+      "description": "Modify whitespace.",
+      "name": "milky-way"
+    },
+    {
       "emoji": "➕",
       "entity": "&#10133;",
       "code": ":heavy_plus_sign:",

--- a/src/styles/_includes/_vars.scss
+++ b/src/styles/_includes/_vars.scss
@@ -45,6 +45,7 @@ $gitmojis: (
   loud-sound: #23b4d2,
   mag: #ffe55f,
   memo: #00e676,
+  milky-way: #816efa,
   mute: #e6ebef,
   ok-hand: #c5e763,
   package: #fdd0ae,


### PR DESCRIPTION
## Description

Adds the 🌌 for whitespace only commits as described in #548.

## Tests

<!-- Ensure that all the tests passed -->
- [X] All tests passed.


Fixes #548 