### PR TITLE
Revise pencil gitmoji

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -1224,7 +1224,7 @@ Array [
           className="emoji-card"
         >
           <header
-            className="pencil emoji-header"
+            className="memo emoji-header"
           >
             <span
               className="emoji-icon gitmoji-emoji"
@@ -1238,10 +1238,10 @@ Array [
           >
             <div
               className="gitmoji-code"
-              data-clipboard-text=":pencil:"
+              data-clipboard-text=":memo:"
             >
               <code>
-                :pencil:
+                :memo:
               </code>
             </div>
             <p>

--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -1245,7 +1245,7 @@ Array [
               </code>
             </div>
             <p>
-              Write docs.
+              Add or update documentation.
             </p>
           </div>
         </div>

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -45,9 +45,9 @@
     {
       "emoji": "📝",
       "entity": "&#x1f4dd;",
-      "code": ":pencil:",
+      "code": ":memo:",
       "description": "Add or update documentation.",
-      "name": "pencil"
+      "name": "memo"
     },
     {
       "emoji": "🚀",

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -46,7 +46,7 @@
       "emoji": "📝",
       "entity": "&#x1f4dd;",
       "code": ":pencil:",
-      "description": "Write docs.",
+      "description": "Add or update documentation.",
       "name": "pencil"
     },
     {


### PR DESCRIPTION
## Description

I made the description of the documentation gitmoji for :memo: conform to the pattern established in many of the other gitmojis. Also, instead of using the nickname "docs" I expanded this into "documentation." I think it is more consistent with the rest of the codebase considering we use "dependencies" instead of "deps."

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
