### PR TITLE
Easier Code Contributions

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+tasks:
+  - init: yarn install
+    command: yarn dev
+
+ports:
+  - port: 3000
+    onOpen: open-preview
+
+vscode:
+  extensions:
+    - flowtype.flow-for-vscode@1.5.0:AwOT6wgHTF43loZQCAUMLA==

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,3 @@
+{
+  "javascript.validate.enable": false
+}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 		<img src="https://img.shields.io/badge/gitmoji-%20😜%20😍-FFDD67.svg?style=flat-square"
 			 alt="Gitmoji">
 	</a>
+  <a href="https://gitpod.io/from-referrer/">
+    <img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue??style=flat-square&logo=gitpod" alt="Gitpod Ready-to-Code">
+  </a>
 </p>
 
 ## About
@@ -43,6 +46,17 @@ npm i -g gitmoji-cli
 ## Contributing to gitmoji
 
 Contributing to gitmoji is a piece of :cake:, read the [contributing guidelines](https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md). You can discuss emojis using the [issues section](https://github.com/carloscuesta/gitmoji/issues/new). To add a new emoji to the list create an issue and send a pull request, see [how to send a pull request and add a gitmoji](https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#how-to-add-a-gitmoji).
+
+### Online one-click setup for code contributions
+
+You can use Gitpod(An Online Open Source VS Code like IDE which is free for Open Source) for contributing. With a single click it will launch a workspace and automatically:
+
+- clone the `gitmoji` repo.
+- install all of the dependencies.
+- run `yarn dev` and open preview for port `3000`.
+- install VS Code `Flow Language Support` extension. 
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ## Spread the word
 


### PR DESCRIPTION
Hi.

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects.

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone the `gitmoji` repo.
- install all of the dependencies.
- run `yarn dev` and open preview for port `3000`.
- install VS Code `Flow Language Support` extension. 

This way anyone interested in contributing can start straight away without any friction.

You can give it a try on my fork of the repo via the following link:
 
https://gitpod.io/#https://github.com/nisarhassan12/gitmoji

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95703551-9c19ca00-0c68-11eb-8d40-d3b80cd1e896.png)


A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  https://github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95134600-9a3d9b80-077c-11eb-89ea-f9a90423e678.png)


## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
