### PR TITLE
🎱 Add 8ball emoji to use when updating Kubernetes manifests files

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -2999,6 +2999,39 @@ Array [
           </div>
         </div>
       </article>
+      <article
+        className="emoji col-xs-12 col-sm-6 col-md-3"
+      >
+        <div
+          className="emoji-card"
+        >
+          <header
+            className="8ball emoji-header"
+          >
+            <span
+              className="emoji-icon gitmoji-emoji"
+              data-clipboard-text="🎱"
+            >
+              🎱
+            </span>
+          </header>
+          <div
+            className="emoji-info"
+          >
+            <div
+              className="gitmoji-code"
+              data-clipboard-text=":8ball:"
+            >
+              <code>
+                :8ball:
+              </code>
+            </div>
+            <p>
+              Setup or Configure K8S manifests.
+            </p>
+          </div>
+        </div>
+      </article>
     </div>
   </main>,
   <footer

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -419,6 +419,13 @@
       "code": ":wastebasket:",
       "description": "Deprecate code that needs to be cleaned up.",
       "name": "wastebasket"
+    },
+    {
+      "emoji": "🎱",
+      "entity": "&#x1F3B1;",
+      "code": ":8ball:",
+      "description": "Setup or Configure K8S manifests.",
+      "name": "8ball"
     }
   ]
 }

--- a/src/styles/_includes/_vars.scss
+++ b/src/styles/_includes/_vars.scss
@@ -8,6 +8,7 @@ $pink: #ff5a79;
 // Emoji colors
 
 $gitmojis: (
+  8ball: #333333,
   alembic: #7f39fb,
   alien: #c5e763,
   ambulance: #fb584a,
@@ -65,6 +66,7 @@ $gitmojis: (
   triangular-flag-on-post: #ffce49,
   truck: #ef584a,
   twisted-rightwards-arrows: #56d1d8,
+  whale: #55acee,
   wastebasket: #d9e3e8,
   wheelchair: #00b1fb,
   white-check-mark: #77e856,


### PR DESCRIPTION
Signed-off-by: andreffs18 <andreffs18@gmail.com>

## Description

This PR adds the 🎱 emoji to indicate when we set up or make some changes on **Kubernetes (k8s)** manifest files.

![image](https://user-images.githubusercontent.com/5011530/97105477-de082e80-16b2-11eb-8230-e0e49b90ce62.png)

## Tests

- [x] All tests passed.
