### PR TITLE
Added a Settings Emoji

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -225,6 +225,13 @@
       "name": "package"
     },
     {
+      "emoji": "⚙️",
+      "entity": "&#x2699;",
+      "code": ":gear:",
+      "description": "Add or update custom settings for the code editor.",
+      "name": "gear"
+    }
+    {
       "emoji": "👽",
       "entity": "&#1F47D;",
       "code": ":alien:",

--- a/src/styles/_includes/_vars.scss
+++ b/src/styles/_includes/_vars.scss
@@ -45,6 +45,7 @@ $gitmojis: (
   loud-sound: #23b4d2,
   mag: #ffe55f,
   memo: #00e676,
+  gear: #636e72,
   mute: #e6ebef,
   ok-hand: #c5e763,
   package: #fdd0ae,


### PR DESCRIPTION
## Description

<!-- Explanation about your pull request, what changes you've made -->
I recently created a `.vscode/settings.json` file a repository. I found that there was no emoji for something like that. So I added the **gear emoji** (⚙️) for "Add or update custom settings for the code editor"
## Tests

<!-- Ensure that all the tests passed -->
- [ ] All tests passed.

Don't know why the tests failed. Is the issue in the `scss` file?