### PR TITLE
💄 Add dark-mode theme

### DIFF
--- a/src/components/GitmojiList/Gitmoji/styles.module.css
+++ b/src/components/GitmojiList/Gitmoji/styles.module.css
@@ -19,6 +19,13 @@
   transform: translateY(-1px);
 }
 
+@media (prefers-color-scheme: dark) {
+  .card:hover {
+    box-shadow: none;
+    background-color: #3b3b3b;
+  }
+}
+
 .cardHeader {
   align-self: flex-start;
   padding-top: 2em;

--- a/src/components/Layout/Header/styles.module.css
+++ b/src/components/Layout/Header/styles.module.css
@@ -8,6 +8,7 @@
   padding: 0.5em 0;
   margin: 0;
   font-size: 2em;
+  color: var(--textInPrimary);
 }
 
 .buttons {

--- a/src/utils/theme/theme.css
+++ b/src/utils/theme/theme.css
@@ -5,6 +5,7 @@
     --primaryShadow: #ffcc1b;
     --secondary: #ff5a79;
     --secondaryShadow: #f3002e;
+    --textInPrimary: #000000;
     --textInSecondary: #ffffff;
     --footerBackground: #00e5ff;
     --cardBackground: #ffffff;
@@ -20,21 +21,26 @@
 
 @media (prefers-color-scheme: dark) {
   html {
-    --background: #ffffff;
+    --background: #121212;
     --primary: #ffdd67;
     --primaryShadow: #ffcc1b;
     --secondary: #ff5a79;
     --secondaryShadow: #f3002e;
+    --textInPrimary: #000000;
     --textInSecondary: #ffffff;
     --footerBackground: #00e5ff;
-    --cardBackground: #ffffff;
-    --cardText: #999999;
-    --emojiCodeText: #000000;
-    --cardShadow: rgba(168, 182, 191, 0.6);
+    --cardBackground: #2b2b2b;
+    --cardText: #ffffff;
+    --emojiCodeText: #ffffff;
+    --cardShadow: none;
     --notificationText: #ffffff;
     --notificationShadow: rgba(0, 0, 0, 0.05);
     --notificationEmojiCodeColor: rgba(0, 0, 0, 0.85);
     --menuBackground: #ff5a79;
+  }
+
+  body {
+    color: var(--cardText);
   }
 }
 
@@ -78,9 +84,10 @@ section {
 
 pre {
   background-color: var(--primary);
-  box-shadow: 0 4px var(--primaryShadow);
-  padding: 1em;
   border-radius: 4px;
+  box-shadow: 0 4px var(--primaryShadow);
+  color: var(--textInPrimary);
+  padding: 1em;
 }
 
 .wrap {


### PR DESCRIPTION
## Description

As I said on #622 one of the reasons behind this refactor was to implement dark-mode, so in this PR i'm revamping #423 by @benavern and implementing a first version of the theme :tada:

From this point we can iterate over the dark version of the website 😊 

cc @vhoyer @johannchopin 

This fixed #423

Thanks to @benavern for the work and the patience 👏🏼  ❤️ 

## Demo

![Screenshot 2020-11-20 at 15 44 15](https://user-images.githubusercontent.com/7629661/99812872-44b02900-2b47-11eb-9345-9d948f7d3302.png)
![Screenshot 2020-11-20 at 15 44 19](https://user-images.githubusercontent.com/7629661/99812885-47128300-2b47-11eb-900d-822e7257938b.png)
