### PR TITLE
✨ Allow searching by gitmoji description

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -473,7 +473,7 @@ exports[`Pages Index should render the page 1`] = `
           className="searchInput"
           name="searchInput"
           onChange={[Function]}
-          placeholder="Search a Gitmoji by :code:"
+          placeholder="Search"
           type="text"
           value={null}
         />

--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -473,7 +473,7 @@ exports[`Pages Index should render the page 1`] = `
           className="searchInput"
           name="searchInput"
           onChange={[Function]}
-          placeholder="Search"
+          placeholder="Search your gitmoji..."
           type="text"
           value={null}
         />

--- a/src/components/GitmojiList/Toolbar/index.js
+++ b/src/components/GitmojiList/Toolbar/index.js
@@ -14,7 +14,7 @@ const Toolbar = (props: Props): Element<'div'> => (
       className={styles.searchInput}
       name="searchInput"
       onChange={(event) => props.setSearchInput(event.target.value)}
-      placeholder="Search"
+      placeholder="Search your gitmoji..."
       type="text"
       value={props.searchInput}
     />

--- a/src/components/GitmojiList/Toolbar/index.js
+++ b/src/components/GitmojiList/Toolbar/index.js
@@ -14,7 +14,7 @@ const Toolbar = (props: Props): Element<'div'> => (
       className={styles.searchInput}
       name="searchInput"
       onChange={(event) => props.setSearchInput(event.target.value)}
-      placeholder="Search a Gitmoji by :code:"
+      placeholder="Search"
       type="text"
       value={props.searchInput}
     />

--- a/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.js.snap
+++ b/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.js.snap
@@ -18,7 +18,7 @@ exports[`GitmojiList should render the component 1`] = `
         className="searchInput"
         name="searchInput"
         onChange={[Function]}
-        placeholder="Search a Gitmoji by :code:"
+        placeholder="Search"
         type="text"
         value={null}
       />

--- a/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.js.snap
+++ b/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.js.snap
@@ -18,7 +18,7 @@ exports[`GitmojiList should render the component 1`] = `
         className="searchInput"
         name="searchInput"
         onChange={[Function]}
-        placeholder="Search"
+        placeholder="Search your gitmoji..."
         type="text"
         value={null}
       />

--- a/src/components/GitmojiList/__tests__/gitmojiList.spec.js
+++ b/src/components/GitmojiList/__tests__/gitmojiList.spec.js
@@ -9,7 +9,7 @@ describe('GitmojiList', () => {
     expect(wrapper).toMatchSnapshot()
   })
 
-  describe('when user search the bookmark gitmoji', () => {
+  describe('when user search the fire gitmoji', () => {
     it('should filter the GitmojiList and find the fire gitmoji by code', () => {
       const wrapper = renderer.create(<GitmojiList {...stubs.props} />)
       const instance = wrapper.root

--- a/src/components/GitmojiList/__tests__/gitmojiList.spec.js
+++ b/src/components/GitmojiList/__tests__/gitmojiList.spec.js
@@ -9,15 +9,28 @@ describe('GitmojiList', () => {
     expect(wrapper).toMatchSnapshot()
   })
 
-  describe('when user search the bug gitmoji', () => {
-    it('should filter the GitmojiList and find the bug gitmoji', () => {
+  describe('when user search the bookmark gitmoji', () => {
+    it('should filter the GitmojiList and find the fire gitmoji by code', () => {
       const wrapper = renderer.create(<GitmojiList {...stubs.props} />)
       const instance = wrapper.root
 
       renderer.act(() => {
         instance
           .findByType('input')
-          .props.onChange({ target: { value: 'Bug' } })
+          .props.onChange({ target: { value: 'Fire' } })
+      })
+
+      expect(instance.findAllByType('article').length).toEqual(1)
+    })
+
+    it('should filter the GitmojiList and find the fire gitmoji by description', () => {
+      const wrapper = renderer.create(<GitmojiList {...stubs.props} />)
+      const instance = wrapper.root
+
+      renderer.act(() => {
+        instance
+          .findByType('input')
+          .props.onChange({ target: { value: 'remove' } })
       })
 
       expect(instance.findAllByType('article').length).toEqual(1)

--- a/src/components/GitmojiList/index.js
+++ b/src/components/GitmojiList/index.js
@@ -18,11 +18,14 @@ type Props = {
 const GitmojiList = (props: Props): Element<'div'> => {
   const [searchInput, setSearchInput] = React.useState(null)
   const gitmojis = searchInput
-    ? props.gitmojis.filter(
-        ({ code, description }) =>
-          code.includes(searchInput.toLowerCase()) ||
-          description.toLowerCase().includes(searchInput.toLowerCase())
-      )
+    ? props.gitmojis.filter(({ code, description }) => {
+        const lowerCasedSearch = searchInput.toLowerCase()
+
+        return (
+          code.includes(lowerCasedSearch) ||
+          description.toLowerCase().includes(lowerCasedSearch)
+        )
+      })
     : props.gitmojis
 
   React.useEffect(() => {

--- a/src/components/GitmojiList/index.js
+++ b/src/components/GitmojiList/index.js
@@ -18,8 +18,10 @@ type Props = {
 const GitmojiList = (props: Props): Element<'div'> => {
   const [searchInput, setSearchInput] = React.useState(null)
   const gitmojis = searchInput
-    ? props.gitmojis.filter((gitmoji) =>
-        gitmoji.code.includes(searchInput.toLowerCase())
+    ? props.gitmojis.filter(
+        ({ code, description }) =>
+          code.includes(searchInput.toLowerCase()) ||
+          description.toLowerCase().includes(searchInput.toLowerCase())
       )
     : props.gitmojis
 


### PR DESCRIPTION
## Description
This should allow the users to find emojis by description as well, for a better UX.

### Before
<img width="1145" alt="Screen Shot 2020-12-08 at 1 19 13 PM" src="https://user-images.githubusercontent.com/30146019/101484110-69830980-3959-11eb-81b5-434a0ecb467b.png">

### After
<img width="1099" alt="Screen Shot 2020-12-08 at 1 29 57 PM" src="https://user-images.githubusercontent.com/30146019/101484153-7bfd4300-3959-11eb-9d9e-c8ed26d42c67.png">

Closes: #640

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
