### PR TITLE
📝 Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/gitmoji-proposal.md
+++ b/.github/ISSUE_TEMPLATE/gitmoji-proposal.md
@@ -1,3 +1,12 @@
+---
+name: 😜 Gitmoji proposal
+about: Suggest a gitmoji!
+title: ''
+labels: emoji
+assignees: ''
+
+---
+
 Hello @carloscuesta :sunglasses:!
 
 <!-- Emoji suggestion: Use this template to propose an emoji -->
@@ -5,7 +14,3 @@ Hello @carloscuesta :sunglasses:!
 - Emoji: :rainbow: <!-- Emoji icon you want to use -->
 - Code: `:rainbow:` <!-- Emoji code on GitHub -->
 - Description: <!-- Describe why this emoji should be used -->
-
-<!-- Other problems -->
-
-<!-- Describe your issue here -->


### PR DESCRIPTION
## Description

Add different `ISSUE_TEMPLATES` rather than having just a single one. This will make users pick one of both templates before creating an issue. Those issues will be labeled automatically 

