### PR TITLE
✨ Add `semver` property to the gitmojis

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you would like to add a new emoji to gitmoji, fill the provided `ISSUE_TEMPLA
 2. Create a new branch with the feature name. (Eg: add-emoji-deploy, fix-website-header)
 3. Make your changes.
 4. Test you changes by running `yarn test`
-    - 4.1. If the snapshots are failing run `yarn test -u` and be sure that the new snapshots match your changes
+   - 4.1. If the snapshots are failing run `yarn test -u` and be sure that the new snapshots match your changes
 5. Commit your changes. Don't forget to add a commit title with an emoji and a description.
 6. Push your changes.
 7. Submit your pull request.
@@ -29,7 +29,8 @@ If you would like to add a new emoji to gitmoji, fill the provided `ISSUE_TEMPLA
   "entity": "entity (Ex: &#x1F440)",
   "code": ":code:",
   "description": "Enter the description for the gitmoji. Use present form for verbs.",
-  "name": "code (same as code but without ':' replace underscores for dashes _ => - )"
+  "name": "code (same as code but without ':' replace underscores for dashes _ => - )",
+  "semver": "The semantic versioning effect (can be `'major'`, `'minor'`, `'patch'` or `null` if the commit has no effect on the version)"
 }
 ```
 

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -5,441 +5,504 @@
       "entity": "&#x1f3a8;",
       "code": ":art:",
       "description": "Improve structure / format of the code.",
-      "name": "art"
+      "name": "art",
+      "semver": null
     },
     {
       "emoji": "⚡️",
       "entity": "&#x26a1;",
       "code": ":zap:",
       "description": "Improve performance.",
-      "name": "zap"
+      "name": "zap",
+      "semver": "patch"
     },
     {
       "emoji": "🔥",
       "entity": "&#x1f525;",
       "code": ":fire:",
       "description": "Remove code or files.",
-      "name": "fire"
+      "name": "fire",
+      "semver": null
     },
     {
       "emoji": "🐛",
       "entity": "&#x1f41b;",
       "code": ":bug:",
       "description": "Fix a bug.",
-      "name": "bug"
+      "name": "bug",
+      "semver": "patch"
     },
     {
       "emoji": "🚑",
       "entity": "&#128657;",
       "code": ":ambulance:",
       "description": "Critical hotfix.",
-      "name": "ambulance"
+      "name": "ambulance",
+      "semver": "patch"
     },
     {
       "emoji": "✨",
       "entity": "&#x2728;",
       "code": ":sparkles:",
       "description": "Introduce new features.",
-      "name": "sparkles"
+      "name": "sparkles",
+      "semver": "minor"
     },
     {
       "emoji": "📝",
       "entity": "&#x1f4dd;",
       "code": ":memo:",
       "description": "Add or update documentation.",
-      "name": "memo"
+      "name": "memo",
+      "semver": null
     },
     {
       "emoji": "🚀",
       "entity": "&#x1f680;",
       "code": ":rocket:",
       "description": "Deploy stuff.",
-      "name": "rocket"
+      "name": "rocket",
+      "semver": null
     },
     {
       "emoji": "💄",
       "entity": "&#ff99cc;",
       "code": ":lipstick:",
       "description": "Add or update the UI and style files.",
-      "name": "lipstick"
+      "name": "lipstick",
+      "semver": "patch"
     },
     {
       "emoji": "🎉",
       "entity": "&#127881;",
       "code": ":tada:",
       "description": "Begin a project.",
-      "name": "tada"
+      "name": "tada",
+      "semver": null
     },
     {
       "emoji": "✅",
       "entity": "&#x2705;",
       "code": ":white_check_mark:",
       "description": "Add or update tests.",
-      "name": "white-check-mark"
+      "name": "white-check-mark",
+      "semver": null
     },
     {
       "emoji": "🔒",
       "entity": "&#x1f512;",
       "code": ":lock:",
       "description": "Fix security issues.",
-      "name": "lock"
+      "name": "lock",
+      "semver": "patch"
     },
     {
       "emoji": "🔖",
       "entity": "&#x1f516;",
       "code": ":bookmark:",
       "description": "Release / Version tags.",
-      "name": "bookmark"
+      "name": "bookmark",
+      "semver": null
     },
     {
       "emoji": "🚨",
       "entity": "&#x1f6a8;",
       "code": ":rotating_light:",
       "description": "Fix compiler / linter warnings.",
-      "name": "rotating-light"
+      "name": "rotating-light",
+      "semver": null
     },
     {
       "emoji": "🚧",
       "entity": "&#x1f6a7;",
       "code": ":construction:",
       "description": "Work in progress.",
-      "name": "construction"
+      "name": "construction",
+      "semver": null
     },
     {
       "emoji": "💚",
       "entity": "&#x1f49a;",
       "code": ":green_heart:",
       "description": "Fix CI Build.",
-      "name": "green-heart"
+      "name": "green-heart",
+      "semver": null
     },
     {
       "emoji": "⬇️",
       "entity": "⬇️",
       "code": ":arrow_down:",
       "description": "Downgrade dependencies.",
-      "name": "arrow-down"
+      "name": "arrow-down",
+      "semver": "patch"
     },
     {
       "emoji": "⬆️",
       "entity": "⬆️",
       "code": ":arrow_up:",
       "description": "Upgrade dependencies.",
-      "name": "arrow-up"
+      "name": "arrow-up",
+      "semver": "patch"
     },
     {
       "emoji": "📌",
       "entity": "&#x1F4CC;",
       "code": ":pushpin:",
       "description": "Pin dependencies to specific versions.",
-      "name": "pushpin"
+      "name": "pushpin",
+      "semver": "patch"
     },
     {
       "emoji": "👷",
       "entity": "&#x1f477;",
       "code": ":construction_worker:",
       "description": "Add or update CI build system.",
-      "name": "construction-worker"
+      "name": "construction-worker",
+      "semver": null
     },
     {
       "emoji": "📈",
       "entity": "&#x1F4C8;",
       "code": ":chart_with_upwards_trend:",
       "description": "Add or update analytics or track code.",
-      "name": "chart-with-upwards-trend"
+      "name": "chart-with-upwards-trend",
+      "semver": "patch"
     },
     {
       "emoji": "♻️",
       "entity": "&#x2672;",
       "code": ":recycle:",
       "description": "Refactor code.",
-      "name": "recycle"
+      "name": "recycle",
+      "semver": null
     },
     {
       "emoji": "➕",
       "entity": "&#10133;",
       "code": ":heavy_plus_sign:",
       "description": "Add a dependency.",
-      "name": "heavy-plus-sign"
+      "name": "heavy-plus-sign",
+      "semver": null
     },
     {
       "emoji": "➖",
       "entity": "&#10134;",
       "code": ":heavy_minus_sign:",
       "description": "Remove a dependency.",
-      "name": "heavy-minus-sign"
+      "name": "heavy-minus-sign",
+      "semver": null
     },
     {
       "emoji": "🔧",
       "entity": "&#x1f527;",
       "code": ":wrench:",
       "description": "Add or update configuration files.",
-      "name": "wrench"
+      "name": "wrench",
+      "semver": "patch"
     },
     {
       "emoji": "🔨",
       "entity": "&#128296;",
       "code": ":hammer:",
       "description": "Add or update development scripts.",
-      "name": "hammer"
+      "name": "hammer",
+      "semver": null
     },
     {
       "emoji": "🌐",
       "entity": "&#127760;",
       "code": ":globe_with_meridians:",
       "description": "Internationalization and localization.",
-      "name": "globe-with-meridians"
+      "name": "globe-with-meridians",
+      "semver": "patch"
     },
     {
       "emoji": "✏️",
       "entity": "&#59161;",
       "code": ":pencil2:",
       "description": "Fix typos.",
-      "name": "pencil2"
+      "name": "pencil2",
+      "semver": "patch"
     },
     {
       "emoji": "💩",
       "entity": "&#58613;",
       "code": ":poop:",
       "description": "Write bad code that needs to be improved.",
-      "name": "poop"
+      "name": "poop",
+      "semver": null
     },
     {
       "emoji": "⏪",
       "entity": "&#9194;",
       "code": ":rewind:",
       "description": "Revert changes.",
-      "name": "rewind"
+      "name": "rewind",
+      "semver": "patch"
     },
     {
       "emoji": "🔀",
       "entity": "&#128256;",
       "code": ":twisted_rightwards_arrows:",
       "description": "Merge branches.",
-      "name": "twisted-rightwards-arrows"
+      "name": "twisted-rightwards-arrows",
+      "semver": null
     },
     {
       "emoji": "📦",
       "entity": "&#1F4E6;",
       "code": ":package:",
       "description": "Add or update compiled files or packages.",
-      "name": "package"
+      "name": "package",
+      "semver": "patch"
     },
     {
       "emoji": "👽",
       "entity": "&#1F47D;",
       "code": ":alien:",
       "description": "Update code due to external API changes.",
-      "name": "alien"
+      "name": "alien",
+      "semver": "patch"
     },
     {
       "emoji": "🚚",
       "entity": "&#1F69A;",
       "code": ":truck:",
       "description": "Move or rename resources (e.g.: files, paths, routes).",
-      "name": "truck"
+      "name": "truck",
+      "semver": null
     },
     {
       "emoji": "📄",
       "entity": "&#1F4C4;",
       "code": ":page_facing_up:",
       "description": "Add or update license.",
-      "name": "page-facing-up"
+      "name": "page-facing-up",
+      "semver": null
     },
     {
       "emoji": "💥",
       "entity": "&#x1f4a5;",
       "code": ":boom:",
       "description": "Introduce breaking changes.",
-      "name": "boom"
+      "name": "boom",
+      "semver": "major"
     },
     {
       "emoji": "🍱",
       "entity": "&#1F371",
       "code": ":bento:",
       "description": "Add or update assets.",
-      "name": "bento"
+      "name": "bento",
+      "semver": "patch"
     },
     {
       "emoji": "♿️",
       "entity": "&#9855;",
       "code": ":wheelchair:",
       "description": "Improve accessibility.",
-      "name": "wheelchair"
+      "name": "wheelchair",
+      "semver": "patch"
     },
     {
       "emoji": "💡",
       "entity": "&#128161;",
       "code": ":bulb:",
       "description": "Add or update comments in source code.",
-      "name": "bulb"
+      "name": "bulb",
+      "semver": null
     },
     {
       "emoji": "🍻",
       "entity": "&#x1f37b;",
       "code": ":beers:",
       "description": "Write code drunkenly.",
-      "name": "beers"
+      "name": "beers",
+      "semver": null
     },
     {
       "emoji": "💬",
       "entity": "&#128172;",
       "code": ":speech_balloon:",
       "description": "Add or update text and literals.",
-      "name": "speech-balloon"
+      "name": "speech-balloon",
+      "semver": "patch"
     },
     {
       "emoji": "🗃",
       "entity": "&#128451;",
       "code": ":card_file_box:",
       "description": "Perform database related changes.",
-      "name": "card-file-box"
+      "name": "card-file-box",
+      "semver": "patch"
     },
     {
       "emoji": "🔊",
       "entity": "&#128266;",
       "code": ":loud_sound:",
       "description": "Add or update logs.",
-      "name": "loud-sound"
+      "name": "loud-sound",
+      "semver": null
     },
     {
       "emoji": "🔇",
       "entity": "&#128263;",
       "code": ":mute:",
       "description": "Remove logs.",
-      "name": "mute"
+      "name": "mute",
+      "semver": null
     },
     {
       "emoji": "👥",
       "entity": "&#128101;",
       "code": ":busts_in_silhouette:",
       "description": "Add or update contributor(s).",
-      "name": "busts-in-silhouette"
+      "name": "busts-in-silhouette",
+      "semver": null
     },
     {
       "emoji": "🚸",
       "entity": "&#128696;",
       "code": ":children_crossing:",
       "description": "Improve user experience / usability.",
-      "name": "children-crossing"
+      "name": "children-crossing",
+      "semver": "patch"
     },
     {
       "emoji": "🏗",
       "entity": "&#1f3d7;",
       "code": ":building_construction:",
       "description": "Make architectural changes.",
-      "name": "building-construction"
+      "name": "building-construction",
+      "semver": null
     },
     {
       "emoji": "📱",
       "entity": "&#128241;",
       "code": ":iphone:",
       "description": "Work on responsive design.",
-      "name": "iphone"
+      "name": "iphone",
+      "semver": "patch"
     },
     {
       "emoji": "🤡",
       "entity": "&#129313;",
       "code": ":clown_face:",
       "description": "Mock things.",
-      "name": "clown-face"
+      "name": "clown-face",
+      "semver": null
     },
     {
       "emoji": "🥚",
       "entity": "&#129370;",
       "code": ":egg:",
       "description": "Add or update an easter egg.",
-      "name": "egg"
+      "name": "egg",
+      "semver": "patch"
     },
     {
       "emoji": "🙈",
       "entity": "&#8bdfe7;",
       "code": ":see_no_evil:",
       "description": "Add or update a .gitignore file.",
-      "name": "see-no-evil"
+      "name": "see-no-evil",
+      "semver": null
     },
     {
       "emoji": "📸",
       "entity": "&#128248;",
       "code": ":camera_flash:",
       "description": "Add or update snapshots.",
-      "name": "camera-flash"
+      "name": "camera-flash",
+      "semver": null
     },
     {
       "emoji": "⚗",
       "entity": "&#128248;",
       "code": ":alembic:",
       "description": "Perform experiments.",
-      "name": "alembic"
+      "name": "alembic",
+      "semver": "patch"
     },
     {
       "emoji": "🔍",
       "entity": "&#128269;",
       "code": ":mag:",
       "description": "Improve SEO.",
-      "name": "mag"
+      "name": "mag",
+      "semver": "patch"
     },
     {
       "emoji": "🏷️",
       "entity": "&#127991;",
       "code": ":label:",
       "description": "Add or update types.",
-      "name": "label"
+      "name": "label",
+      "semver": "patch"
     },
     {
       "emoji": "🌱",
       "entity": "&#127793;",
       "code": ":seedling:",
       "description": "Add or update seed files.",
-      "name": "seedling"
+      "name": "seedling",
+      "semver": null
     },
     {
       "emoji": "🚩",
       "entity": "&#x1F6A9;",
       "code": ":triangular_flag_on_post:",
       "description": "Add, update, or remove feature flags.",
-      "name": "triangular-flag-on-post"
+      "name": "triangular-flag-on-post",
+      "semver": "patch"
     },
     {
       "emoji": "🥅",
       "entity": "&#x1F945;",
       "code": ":goal_net:",
       "description": "Catch errors.",
-      "name": "goal-net"
+      "name": "goal-net",
+      "semver": "patch"
     },
     {
       "emoji": "💫",
       "entity": "&#x1f4ab;",
       "code": ":dizzy:",
       "description": "Add or update animations and transitions.",
-      "name": "animation"
+      "name": "animation",
+      "semver": "patch"
     },
     {
       "emoji": "🗑",
       "entity": "&#x1F5D1;",
       "code": ":wastebasket:",
       "description": "Deprecate code that needs to be cleaned up.",
-      "name": "wastebasket"
+      "name": "wastebasket",
+      "semver": "patch"
     },
     {
       "emoji": "🛂",
       "entity": "&#x1F6C2;",
       "code": ":passport_control:",
       "description": "Work on code related to authorization, roles and permissions.",
-      "name": "passport-control"
+      "name": "passport-control",
+      "semver": "patch"
     },
     {
       "emoji": "🩹",
       "entity": "&#x1FA79;",
       "code": ":adhesive_bandage:",
       "description": "Simple fix for a non-critical issue.",
-      "name": "adhesive-bandage"
+      "name": "adhesive-bandage",
+      "semver": "patch"
     },
     {
       "emoji": "🧐",
       "entity": "&#x1F9D0;",
       "code": ":monocle_face:",
       "description": "Data exploration/inspection.",
-      "name": "monocle-face"
+      "name": "monocle-face",
+      "semver": null
     }
   ]
 }

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -182,7 +182,7 @@
       "code": ":heavy_plus_sign:",
       "description": "Add a dependency.",
       "name": "heavy-plus-sign",
-      "semver": null
+      "semver": "patch"
     },
     {
       "emoji": "➖",
@@ -190,7 +190,7 @@
       "code": ":heavy_minus_sign:",
       "description": "Remove a dependency.",
       "name": "heavy-minus-sign",
-      "semver": null
+      "semver": "patch"
     },
     {
       "emoji": "🔧",

--- a/src/data/schema.json
+++ b/src/data/schema.json
@@ -36,6 +36,11 @@
             "type": "string",
             "id": "http://jsonschema.net/gitmojis/0/name",
             "required": true
+          },
+          "semver": {
+            "enum": ["major", "minor", "patch", null],
+            "id": "http://jsonschema.net/gitmojis/0/semver",
+            "required": true
           }
         }
       }


### PR DESCRIPTION
Closes: #429
## Description
### What?
This PR adds a `semver` property to each Gitmoji. The `semver` property can be `'major'` for breaking changes, `'minor'` for new features, `'patch'` for bugfixes/small improvements and `null` if the commit doesn't affect the version of the package.

### Why?
Gitmojis are too granular, and we need a higher level grouping to know what kind of effect does each gitmoji/commit have on the project, which is necessary to be able to automate the package publishing process and so on.
Right now, there are some third-party projects that try to do this grouping on their side, but because there is a big room of interpretation of each emoji, they are not consistent.

### Things to keep in mind
- This is my interpretation of the gitmojis, please drop your comments, so we find a common ground.
- The semantic versioning effect is based on the final package, and not the repo itself, so 🚚 for instance has no effect from my point of view, unless it affects the final package, and in that case the developer should use 💥  instead.

## Tests

- [x] All tests passed.
