### PR TITLE
✨ Added remove dead code emoji (🪦)

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -3116,6 +3116,47 @@ exports[`Pages Index should render the page 1`] = `
         </div>
       </div>
     </article>
+    <article
+      className="emoji col-xs-12 col-sm-6 col-md-3"
+      style={
+        Object {
+          "--emojiColor": "#d9e3e8",
+        }
+      }
+    >
+      <div
+        className="card "
+      >
+        <header
+          className="cardHeader"
+        >
+          <button
+            className="gitmoji-clipboard-emoji gitmoji"
+            data-clipboard-text="🪦"
+            type="button"
+          >
+            🪦
+          </button>
+        </header>
+        <div
+          className="gitmojiInfo"
+        >
+          <button
+            className="gitmoji-clipboard-code gitmojiCode"
+            data-clipboard-text=":headstone:"
+            tabIndex="-1"
+            type="button"
+          >
+            <code>
+              :headstone:
+            </code>
+          </button>
+          <p>
+            Remove dead code
+          </p>
+        </div>
+      </div>
+    </article>
   </div>
 </main>
 `;

--- a/src/components/GitmojiList/emojiColorsMap.js
+++ b/src/components/GitmojiList/emojiColorsMap.js
@@ -29,6 +29,7 @@ export default {
   'goal-net': '#c7cb12',
   'green-heart': '#c5e763',
   hammer: '#ffc400',
+  headstone: '#d9e3e8',
   'heavy-minus-sign': '#ef5350',
   'heavy-plus-sign': '#00e676',
   iphone: '#40c4ff',

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -503,6 +503,14 @@
       "description": "Data exploration/inspection.",
       "name": "monocle-face",
       "semver": null
+    },
+    {
+      "emoji": "🪦",
+      "entity": "&#x1FAA6;",
+      "code": ":headstone:",
+      "description": "Remove dead code",
+      "name": "headstone",
+      "semver": null
     }
   ]
 }


### PR DESCRIPTION
<!--
Please, before opening a PR, first open an issue as stated in the [contributing guidelines][1],
so we can talk about features and discuss implementations.

[1]: https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#contributing-to-gitmoji
-->

## Description

I added headstone emoji (🪦) because we can need to have emoji to inform others about dead code deleted.

For example, we started a new project inside our monorepo but this project is cancelled. We need to delete it and a headstone fit perfectly to this usage. 

Second example, you deleting old code not used anymore.

Thank you for this beautiful specification !

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
