### PR TITLE
✨ Introduce Gitmoji API

### DIFF
--- a/src/__tests__/pages.spec.js
+++ b/src/__tests__/pages.spec.js
@@ -5,6 +5,8 @@ import Index from '../pages/index'
 import About from '../pages/about'
 import Contributors from '../pages/contributors'
 import RelatedTools from '../pages/related-tools'
+import GitmojisApi from '../pages/api/gitmojis'
+import gitmojisData from '../data/gitmojis.json'
 import * as stubs from './stubs'
 
 jest.mock('next/router', () => ({
@@ -52,6 +54,37 @@ describe('Pages', () => {
     it('should render the page', () => {
       const wrapper = renderer.create(<RelatedTools />)
       expect(wrapper).toMatchSnapshot()
+    })
+  })
+
+  describe('Api', () => {
+    describe('gitmojis endpoint', () => {
+      describe('when request method is GET', () => {
+        it('should set response status to 200 and gitmojis as body json', () => {
+          const request = stubs.request('GET')
+          const response = stubs.response()
+
+          GitmojisApi(request, response)
+
+          expect(response.status).toHaveBeenCalledWith(200)
+          expect(response.json).toHaveBeenCalledWith(gitmojisData)
+        })
+      })
+
+      describe('when request method is not GET', () => {
+        it('should setHeader, status 405 and end the request', () => {
+          const request = stubs.request('POST')
+          const response = stubs.response()
+
+          GitmojisApi(request, response)
+
+          expect(response.setHeader).toHaveBeenCalledWith('Allow', ['GET'])
+          expect(response.status).toHaveBeenCalledWith(405)
+          expect(response.json).toHaveBeenCalledWith({
+            error: `Error: method POST not allowed`,
+          })
+        })
+      })
     })
   })
 })

--- a/src/__tests__/stubs.js
+++ b/src/__tests__/stubs.js
@@ -2,3 +2,17 @@ export const appProps = {
   Component: (props) => <div {...props}>Component</div>,
   pageProps: { test: '' },
 }
+
+export const request = (method) => ({ method })
+
+export const response = () => {
+  const response = {}
+
+  response.status = jest.fn().mockReturnValue(response)
+  response.json = jest.fn().mockReturnValue(response)
+  response.setHeader = jest.fn().mockReturnValue(response)
+  response.status = jest.fn().mockReturnValue(response)
+  response.end = jest.fn().mockReturnValue(response)
+
+  return response
+}

--- a/src/pages/api/gitmojis/index.js
+++ b/src/pages/api/gitmojis/index.js
@@ -1,0 +1,16 @@
+// @flow
+import gitmojisData from 'src/data/gitmojis.json'
+
+const gitmojis = (request: { method: string }, response: Object): void => {
+  const { method } = request
+
+  if (method === 'GET') {
+    response.status(200).json(gitmojisData)
+    return
+  }
+
+  response.setHeader('Allow', ['GET'])
+  response.status(405).json({ error: `Error: method ${method} not allowed` })
+}
+
+export default gitmojis


### PR DESCRIPTION
## Description

Hello! 👋🏼 

This PRs introduces the first endpoint of the `Gitmoji` API 🎉 

The main idea behind this endpoint would be to fix the following error that some users of `gitmoji-cli` that live on countries that block `raw.githubusercontent.com` get - https://github.com/carloscuesta/gitmoji-cli/issues/552

The gitmojis could be consumed through the following endpoint: 

```
GET: https://gitmoji.dev/api/gitmojis
```

To implement this as an API endpoint we're using the [Next.js API Routes feature](https://nextjs.org/docs/api-routes/introduction)

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
