### PR TITLE
:bug: Render unicode gitmojis as image by default

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -33,7 +33,7 @@
       "semver": "patch"
     },
     {
-      "emoji": "🚑",
+      "emoji": "🚑️",
       "entity": "&#128657;",
       "code": ":ambulance:",
       "description": "Critical hotfix.",
@@ -89,7 +89,7 @@
       "semver": null
     },
     {
-      "emoji": "🔒",
+      "emoji": "🔒️",
       "entity": "&#x1f512;",
       "code": ":lock:",
       "description": "Fix security issues.",
@@ -233,7 +233,7 @@
       "semver": null
     },
     {
-      "emoji": "⏪",
+      "emoji": "⏪️",
       "entity": "&#9194;",
       "code": ":rewind:",
       "description": "Revert changes.",
@@ -249,7 +249,7 @@
       "semver": null
     },
     {
-      "emoji": "📦",
+      "emoji": "📦️",
       "entity": "&#1F4E6;",
       "code": ":package:",
       "description": "Add or update compiled files or packages.",
@@ -257,7 +257,7 @@
       "semver": "patch"
     },
     {
-      "emoji": "👽",
+      "emoji": "👽️",
       "entity": "&#1F47D;",
       "code": ":alien:",
       "description": "Update code due to external API changes.",
@@ -329,7 +329,7 @@
       "semver": "patch"
     },
     {
-      "emoji": "🗃",
+      "emoji": "🗃️",
       "entity": "&#128451;",
       "code": ":card_file_box:",
       "description": "Perform database related changes.",
@@ -369,7 +369,7 @@
       "semver": "patch"
     },
     {
-      "emoji": "🏗",
+      "emoji": "🏗️",
       "entity": "&#1f3d7;",
       "code": ":building_construction:",
       "description": "Make architectural changes.",
@@ -417,7 +417,7 @@
       "semver": null
     },
     {
-      "emoji": "⚗",
+      "emoji": "⚗️",
       "entity": "&#128248;",
       "code": ":alembic:",
       "description": "Perform experiments.",
@@ -425,7 +425,7 @@
       "semver": "patch"
     },
     {
-      "emoji": "🔍",
+      "emoji": "🔍️",
       "entity": "&#128269;",
       "code": ":mag:",
       "description": "Improve SEO.",
@@ -473,7 +473,7 @@
       "semver": "patch"
     },
     {
-      "emoji": "🗑",
+      "emoji": "🗑️",
       "entity": "&#x1F5D1;",
       "code": ":wastebasket:",
       "description": "Deprecate code that needs to be cleaned up.",


### PR DESCRIPTION
Some emojis are rendered as text by default, other as image. The result
is that some gitmojis are different / a bit ugly depending on the font
used. This concerns only the unicode version of the gitmoji, not the
:code: one.

Emojis are rendered either by text or picture. Variation selectors
VS15 and VS16 define if text or picture representation should be used.

According to [0], the following gitmojis are affected by those selectors
and may be rendered as text:

- alembic
- alien
- ambulance
- *arrow-down
- *arrow-up
- building-construction
- card-file-box
- *coffin
- *label
- lock
- mag
- package
- *pencil2
- *recycle
- rewind
- wastebasket
- *wheelchair
- *zap

Out of those, 8 already have VS16 (\ufe0f), and will be rendered as
image. This commit unifies the 10 other ones by adding the selector.

[0]: https://www.unicode.org/Public/13.0.0/ucd/emoji/emoji-variation-sequences.txt