### PR TITLE
Add emoji business logic Resolves #723

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -3212,6 +3212,47 @@ exports[`Pages Index should render the page 1`] = `
         </div>
       </div>
     </article>
+    <article
+      className="emoji col-xs-12 col-sm-6 col-md-3"
+      style={
+        Object {
+          "--emojiColor": "#83beec",
+        }
+      }
+    >
+      <div
+        className="card "
+      >
+        <header
+          className="cardHeader"
+        >
+          <button
+            className="gitmoji-clipboard-emoji gitmoji"
+            data-clipboard-text="👔"
+            type="button"
+          >
+            👔
+          </button>
+        </header>
+        <div
+          className="gitmojiInfo"
+        >
+          <button
+            className="gitmoji-clipboard-code gitmojiCode"
+            data-clipboard-text=":necktie:"
+            tabIndex="-1"
+            type="button"
+          >
+            <code>
+              :necktie:
+            </code>
+          </button>
+          <p>
+            Add or update business logic
+          </p>
+        </div>
+      </div>
+    </article>
   </div>
 </main>
 `;

--- a/src/components/GitmojiList/emojiColorsMap.js
+++ b/src/components/GitmojiList/emojiColorsMap.js
@@ -67,4 +67,5 @@ export default {
   wrench: '#ffc400',
   zap: '#40c4ff',
   'monocle-face': '#ffe55f',
+  necktie: '#83beec',
 }

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -519,6 +519,14 @@
       "description": "Add a failing test.",
       "name": "test-tube",
       "semver": null
+    },
+    {
+      "emoji": "👔",
+      "entity": "&#128084;",
+      "code": ":necktie:",
+      "description": "Add or update business logic",
+      "name": "necktie",
+      "semver": "patch"
     }
   ]
 }


### PR DESCRIPTION
## Description

We have ✨ for additional features, but "features" for some projects imply only public behaviors. Adding utility functions, interfaces, wrappers, or any business/domain logic, for most public-facing libraries/projects would not be considered a "new feature". These additions live in the business/domain layer and are only for internal usage and will never be exposed via UI or API. Therefore, there is no good emoji in gitmoji to represent clearly that the addition or change is only meant for the business/domain layer.

👔 as suggested by #723 would resolve all these internal business logic commits and clarify that additions/changes are internal, not public, and live in the business/domain layer.

This may have some overlap with ♻️ (representing refactoring) as a change to business logic could sometimes be considered refactoring. However, I think ♻️ could consider being more specific and cover changes to the internal behavior of a module or function that do not affect inputs or outputs.

This may have some overlap with 🏗️ (representing architectural changes) as changes to the architecture could very well represent changes to business logic as well. However, I think 🏗️ would better represent major changes to the flow while 👔 would represent minor changes to input and output.

Ultimately, it would be up to the commiter to determine if the changes are big enough to be 🏗️, small enough to be ♻️, or fit perfectly with 👔. Any additions to the business/domain layer would almost always be 👔.

## Tests

- [x] Rebuild snapshot
- [x] All tests passed.
