### PR TITLE
:bug: Emoji code not working

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -539,7 +539,7 @@
     {
       "emoji": "🧱",
       "entity": "&#x1f9f1;",
-      "code": ":brick:",
+      "code": ":bricks:",
       "description": "Infrastructure related changes.",
       "name": "brick",
       "semver": null


### PR DESCRIPTION
I've used the `:brick:` as commit message but GitHub doesn't render any brick emoji, afik `:bricks:` is working!
🧱

<!--
Please, before opening a PR, first open an issue as stated in the [contributing guidelines][1],
so we can talk about features and discuss implementations.

[1]: https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#contributing-to-gitmoji
-->

## Description
Fixing bricks emoji
<!-- Explanation about your pull request, what changes you've made -->

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
