### PR TITLE
:sparkles: Add 'Add or Remove Secrets.' :closed_lock_with_key: emoji

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -1062,6 +1062,47 @@ exports[`Pages Index should render the page 1`] = `
       className="emoji col-xs-12 col-sm-6 col-md-3"
       style={
         Object {
+          "--emojiColor": "#83beec",
+        }
+      }
+    >
+      <div
+        className="card "
+      >
+        <header
+          className="cardHeader"
+        >
+          <button
+            className="gitmoji-clipboard-emoji gitmoji"
+            data-clipboard-text="🔐"
+            type="button"
+          >
+            🔐
+          </button>
+        </header>
+        <div
+          className="gitmojiInfo"
+        >
+          <button
+            className="gitmoji-clipboard-code gitmojiCode"
+            data-clipboard-text=":closed_lock_with_key:"
+            tabIndex="-1"
+            type="button"
+          >
+            <code>
+              :closed_lock_with_key:
+            </code>
+          </button>
+          <p>
+            Add or update secrets.
+          </p>
+        </div>
+      </div>
+    </article>
+    <article
+      className="emoji col-xs-12 col-sm-6 col-md-3"
+      style={
+        Object {
           "--emojiColor": "#80deea",
         }
       }

--- a/src/components/GitmojiList/emojiColorsMap.js
+++ b/src/components/GitmojiList/emojiColorsMap.js
@@ -36,6 +36,7 @@ export default {
   label: '#cb63e6',
   lipstick: '#80deea',
   lock: '#ffce49',
+  'closed-lock-with-key': '#83beec',
   'loud-sound': '#23b4d2',
   mag: '#ffe55f',
   memo: '#00e676',

--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -97,6 +97,14 @@
       "semver": "patch"
     },
     {
+      "emoji": "🔐",
+      "entity": "&#x1f510;",
+      "code": ":closed_lock_with_key:",
+      "description": "Add or update secrets.",
+      "name": "closed-lock-with-key",
+      "semver": null
+    },
+    {
       "emoji": "🔖",
       "entity": "&#x1f516;",
       "code": ":bookmark:",


### PR DESCRIPTION
<!--
Please, before opening a PR, first open an issue as stated in the [contributing guidelines][1],
so we can talk about features and discuss implementations.

[1]: https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#contributing-to-gitmoji
-->

## Description
Relates to https://github.com/carloscuesta/gitmoji/issues/922

Adds an Emoji for adding/removing secrets.
Whether or not its _good_ practice, many programmers version secrets in git repositories with `git-crypt`, `SOPS`, etc.

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
