### PR TITLE
Add gitmoji-regex

### DIFF
--- a/src/pages/related-tools.js
+++ b/src/pages/related-tools.js
@@ -48,6 +48,11 @@ const tools: Array<{ name: string, description: string, link: string }> = [
     link: 'https://github.com/ThatXliner/gitmoji-atom',
   },
   {
+    name: 'gitmoji-regex',
+    description: 'A Gitmoji::Regex for Ruby.',
+    link: 'https://github.com/pboling/gitmoji-regex',
+  },
+  {
     name: 'traymoji',
     description: 'A Electron Tray App for Gitmojis',
     link: 'https://github.com/CoenWarmer/traymoji',


### PR DESCRIPTION
Add Gitmoji::Regex for Ruby to `src/pages/related-tools.js`

See #1011 

https://github.com/pboling/gitmoji-regex

The Ruby Gitmoji Regex will be useful for testing strings for the presence of Gitmoji characters.  It relies on the [gitmoji JSON](https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json) from this project, and has a script for updating, as well as a spec that will fail the build as soon as it gets out of sync with this canon.