### PR TITLE
:adhesive_bandage: use for recycle emoji and entity same number

### DIFF
--- a/src/data/gitmojis.json
+++ b/src/data/gitmojis.json
@@ -178,7 +178,7 @@
     },
     {
       "emoji": "♻️",
-      "entity": "&#x2672;",
+      "entity": "&#x267b;",
       "code": ":recycle:",
       "description": "Refactor code.",
       "name": "recycle",


### PR DESCRIPTION
## Description

The hex number used for the recycle emoji is 0x267b and the entity is 0x2672.

The code name suggest 0x267b.
Also [emojipedia on 0x2672](https://emojipedia.org/universal-recycling-symbol/):

    This Unicode character has no emoji version, meaning this is intended to
    display only as a black and white glyph on most platforms. It has not been
    Recommended For General Interchange (RGI) — as an emoji — by Unicode.

Change entity to 0x267b.

## Tests

- [X] All tests passed.
