### PR TITLE
✨ Add githubmoji to /related-tools

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -3724,6 +3724,18 @@ exports[`Pages Related tools should render the page 1`] = `
         </a>
         : A Flutter Gitmoji App for macOS, Linux, and Windows
       </li>
+      <li>
+        <a
+          href="https://github.com/ma1ted/githubmoji"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <b>
+            githubmoji
+          </b>
+        </a>
+        : A Firefox addon that adds a predictive gitmoji picker to GitHub commit message inputs.
+      </li>
     </ul>
   </section>
 </main>

--- a/src/pages/related-tools.js
+++ b/src/pages/related-tools.js
@@ -67,6 +67,12 @@ const tools: Array<{ name: string, description: string, link: string }> = [
     description: 'A Flutter Gitmoji App for macOS, Linux, and Windows',
     link: 'https://github.com/patrick-fu/GitmojiApp',
   },
+  {
+    name: 'githubmoji',
+    description:
+      'A Firefox addon that adds a predictive gitmoji picker to GitHub commit message inputs.',
+    link: 'https://github.com/ma1ted/githubmoji',
+  },
 ]
 
 const RelatedTools = () => (


### PR DESCRIPTION
Fixes https://github.com/carloscuesta/gitmoji/issues/1109

<!--
Please, before opening a PR, first open an issue as stated in the [contributing guidelines][1],
so we can talk about features and discuss implementations.

[1]: https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#contributing-to-gitmoji
-->

## Description

Adds https://github.com/ma1ted/githubmoji to `/related-tools`

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
