### PR TITLE
✨ Add gitmoji-changelog-action to related tools

### DIFF
--- a/src/__tests__/__snapshots__/pages.spec.js.snap
+++ b/src/__tests__/__snapshots__/pages.spec.js.snap
@@ -3783,6 +3783,18 @@ exports[`Pages Related tools should render the page 1`] = `
         </a>
         : A Firefox addon that adds a predictive gitmoji picker to GitHub commit message inputs.
       </li>
+      <li>
+        <a
+          href="https://github.com/sercanuste/gitmoji-changelog-action"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          <b>
+            gitmoji-changelog-action
+          </b>
+        </a>
+        : GitHub Action for gitmoji-changelog
+      </li>
     </ul>
   </section>
 </main>

--- a/src/pages/related-tools.js
+++ b/src/pages/related-tools.js
@@ -73,6 +73,11 @@ const tools: Array<{ name: string, description: string, link: string }> = [
       'A Firefox addon that adds a predictive gitmoji picker to GitHub commit message inputs.',
     link: 'https://github.com/ma1ted/githubmoji',
   },
+  {
+    name: 'gitmoji-changelog-action',
+    description: 'GitHub Action for gitmoji-changelog',
+    link: 'https://github.com/sercanuste/gitmoji-changelog-action',
+  },
 ]
 
 const RelatedTools = () => (


### PR DESCRIPTION
## Description

This PR adds a reference to  [sercanuste/gitmoji-changelog-action](https://github.com/sercanuste/gitmoji-changelog-action) repository at Related Tools page.

I developed a GitHub Action for auto generate CHANGELOG with [gitmoji-changelog](https://github.com/frinyvonnick/gitmoji-changelog).

You can access to the action on [GitHub Marketplace](https://github.com/marketplace/actions/generate-gitmoji-changelog).

## Tests

<!-- Ensure that all the tests passed -->
- [x] All tests passed.
