### PR TITLE
✨Add support to search by emoji

### DIFF
--- a/src/components/GitmojiList/__tests__/gitmojiList.spec.js
+++ b/src/components/GitmojiList/__tests__/gitmojiList.spec.js
@@ -65,6 +65,20 @@ describe('GitmojiList', () => {
 
       expect(instance.findAllByType('article').length).toEqual(1)
     })
+
+    it('should find the fire gitmoji by emoji', () => {
+      const wrapper = renderer.create(<GitmojiList {...stubs.props} />)
+      const instance = wrapper.root
+      const query = '🔥'
+
+      renderer.act(() => {
+        instance
+          .findByType('input')
+          .props.onChange({ target: { value: query } })
+      })
+
+      expect(instance.findAllByType('article').length).toEqual(1)
+    })
   })
 
   describe('when search is provided by query string', () => {

--- a/src/components/GitmojiList/index.js
+++ b/src/components/GitmojiList/index.js
@@ -22,12 +22,13 @@ const GitmojiList = (props: Props): Element<'div'> => {
   const [isListMode, setIsListMode] = useLocalStorage('isListMode', false)
 
   const gitmojis = searchInput
-    ? props.gitmojis.filter(({ code, description }) => {
+    ? props.gitmojis.filter(({ emoji, code, description }) => {
         const lowerCasedSearch = searchInput.toLowerCase()
 
         return (
           code.includes(lowerCasedSearch) ||
-          description.toLowerCase().includes(lowerCasedSearch)
+          description.toLowerCase().includes(lowerCasedSearch) ||
+          emoji == searchInput
         )
       })
     : props.gitmojis


### PR DESCRIPTION
Fixes Issue: #1163 

## Description
Compare searchinput with emojis in the data. Showing the emoji that match.

Examples:
<img width="1134" alt="Success" src="https://user-images.githubusercontent.com/22985190/198068715-a21f24e0-cd51-46b7-9960-01ee7e51a5a7.png">
<img width="1134" alt="Failure" src="https://user-images.githubusercontent.com/22985190/198068931-03d83c94-692a-4ae9-b8c4-8f4f0645539e.png">




## Tests

- [X] All tests passed.
