### PR TITLE
🔧 Enable `dependabot` for `github-actions`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
     interval: weekly
     time: "04:00"
   open-pull-requests-limit: 10
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "04:00"


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR enables Dependabot for GitHub-actions dependencies.
