### PR TITLE
👷 Run `lint` before `publishPackage` with turbo

### DIFF
--- a/packages/gitmojis/package.json
+++ b/packages/gitmojis/package.json
@@ -8,8 +8,7 @@
   ],
   "scripts": {
     "lint": "jsonlint ./src/gitmojis.json -V ./src/schema.json",
-    "publishPackage": "npm publish",
-    "prepublishPackage": "yarn run lint"
+    "publishPackage": "npm publish"
   },
   "devDependencies": {
     "jsonlint": "^1.6.3",

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,7 @@
       "outputs": ["packages/website/.next/**", "packages/website/public/**"]
     },
     "publishPackage": {
+      "dependsOn": ["^lint"],
       "outputs": []
     }
   }


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR runs the `lint` script before publishing the package to the registry using turborepo. 

