### PR TITLE
🔧 Add `eslint-plugin-import` plugin

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -25,6 +25,8 @@
     "eslint-config-next": "^13.1.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-alias": "^1.1.2",
+    "eslint-import-resolver-typescript": "^3.5.2",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^27.1.3",
     "eslint-plugin-react": "^7.31.10",
     "focus-trap-react": "^10.0.0",
@@ -85,7 +87,8 @@
       "plugin:@typescript-eslint/recommended",
       "plugin:react/recommended",
       "prettier",
-      "plugin:@next/next/recommended"
+      "plugin:@next/next/recommended",
+      "plugin:import/typescript"
     ],
     "parserOptions": {
       "ecmaFeatures": {
@@ -102,7 +105,8 @@
     },
     "plugins": [
       "react",
-      "@typescript-eslint"
+      "@typescript-eslint",
+      "import"
     ],
     "rules": {
       "react/react-in-jsx-scope": "off",
@@ -114,6 +118,13 @@
             "jsx",
             "global"
           ]
+        }
+      ],
+      "import/order":[
+        "error",
+        {
+          "groups": [["builtin", "external"],  ["internal","parent", "sibling", "index"]],
+          "newlines-between": "always"
         }
       ]
     },
@@ -129,7 +140,9 @@
               "./src"
             ]
           ]
-        }
+        },
+        "typescript": true,
+        "node": true
       }
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8933,6 +8933,8 @@ __metadata:
     eslint-config-next: ^13.1.1
     eslint-config-prettier: ^8.5.0
     eslint-import-resolver-alias: ^1.1.2
+    eslint-import-resolver-typescript: ^3.5.2
+    eslint-plugin-import: ^2.26.0
     eslint-plugin-jest: ^27.1.3
     eslint-plugin-react: ^7.31.10
     focus-trap-react: ^10.0.0


### PR DESCRIPTION
<!--
Please, before opening a PR, first open an issue as stated in the [contributing guidelines][1],
so we can talk about features and discuss implementations.

[1]: https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#contributing-to-gitmoji
-->

## Description

<!-- Explanation about your pull request, what changes you've made -->
I have follow doc from https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md

Currently, the plugin sort like this: 
```js
// 1. node "builtin" &  "external" modules
import fs from 'fs';
import path from 'path';
import _ from 'lodash';
import chalk from 'chalk';
// # a space between

// 2. "internal" & "parent" & "sibling" & "index" modules
import foo from 'src/foo';
import foo from '../foo';
import qux from '../../foo/qux';
import bar from './bar';
import baz from './bar/baz';
import main from './';
```

If necessary, I can edit and sort the imports alphabetically.



## Linked issues

Close #1243 