### PR TITLE
🚸 Update search input `type`

### DIFF
--- a/packages/website/src/__tests__/__snapshots__/pages.spec.tsx.snap
+++ b/packages/website/src/__tests__/__snapshots__/pages.spec.tsx.snap
@@ -591,7 +591,7 @@ exports[`Pages Index should render the page 1`] = `
             name="searchInput"
             onChange={[Function]}
             placeholder="Search your gitmoji..."
-            type="text"
+            type="search"
             value=""
           />
           <kbd

--- a/packages/website/src/components/GitmojiList/Toolbar/index.tsx
+++ b/packages/website/src/components/GitmojiList/Toolbar/index.tsx
@@ -51,7 +51,7 @@ const Toolbar = (props: Props) => {
           name="searchInput"
           onChange={(event) => props.setSearchInput(event.target.value)}
           placeholder="Search your gitmoji..."
-          type="text"
+          type="search"
           value={props.searchInput}
         />
 

--- a/packages/website/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.tsx.snap
+++ b/packages/website/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.tsx.snap
@@ -19,7 +19,7 @@ exports[`GitmojiList when is list mode should render the component 1`] = `
           name="searchInput"
           onChange={[Function]}
           placeholder="Search your gitmoji..."
-          type="text"
+          type="search"
           value=""
         />
         <kbd
@@ -345,7 +345,7 @@ exports[`GitmojiList when is not list mode should render the component 1`] = `
           name="searchInput"
           onChange={[Function]}
           placeholder="Search your gitmoji..."
-          type="text"
+          type="search"
           value=""
         />
         <kbd


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR updates the search input type to `search` to show the clear button and enable `ESC` key as a clear key.

## Linked issues

Fixes https://github.com/carloscuesta/gitmoji/issues/1190