### PR TITLE
📝(related tools): Add gitmoji-fuzzy-hook

### DIFF
--- a/packages/website/src/pages/related-tools.tsx
+++ b/packages/website/src/pages/related-tools.tsx
@@ -89,7 +89,7 @@ const tools = [
     name: 'genmoji',
     description: 'Gitmoji commit message generation using AI',
     link: 'https://github.com/segersniels/genmoji',
-  }
+  },
 ]
 
 const RelatedTools = () => (

--- a/packages/website/src/pages/related-tools.tsx
+++ b/packages/website/src/pages/related-tools.tsx
@@ -79,6 +79,12 @@ const tools = [
     description: 'Gitmoji extension for Raycast',
     link: 'https://www.raycast.com/ricoberger/gitmoji',
   },
+  {
+    name: 'gitmoji-fuzzy-hook',
+    description:
+      'Fuzzy finder git-commit-hook for prepending a gitmoji (cmd & GUI).',
+    link: 'https://gitlab.com/raabf/gitmoji-fuzzy-hook',
+  },
 ]
 
 const RelatedTools = () => (


### PR DESCRIPTION
## Description

A PR to add a  link to the [`gitmoji-fuzzy-hook`](https://gitlab.com/raabf/gitmoji-fuzzy-hook) to the related tools page.

It is a tool which can be installed as git-commit-hook. Every time you make an `git commit` (either with or without `-m` or  from a GUI) you can select an emoji and it will be prepended to the git commit message so that you do never forget to select a gitmoji and do not have to copy a gitmoji via clipboard.

I use it sucessfully for some years now. I would be glad if you can add it :smile: .

## Linked issues

No one