### PR TITLE
📝 Related Tools: add Genmoji

### DIFF
--- a/packages/website/src/pages/related-tools.tsx
+++ b/packages/website/src/pages/related-tools.tsx
@@ -82,7 +82,7 @@ const tools = [
   {
     name: 'genmoji',
     description: 'Gitmoji commit message generation using AI',
-    link: 'https://genmoji.xyz',
+    link: 'https://github.com/segersniels/genmoji',
   },
 ]
 

--- a/packages/website/src/pages/related-tools.tsx
+++ b/packages/website/src/pages/related-tools.tsx
@@ -79,6 +79,11 @@ const tools = [
     description: 'Gitmoji extension for Raycast',
     link: 'https://www.raycast.com/ricoberger/gitmoji',
   },
+  {
+    name: 'genmoji',
+    description: 'Gitmoji commit message generation using AI',
+    link: 'https://genmoji.xyz',
+  },
 ]
 
 const RelatedTools = () => (


### PR DESCRIPTION
## Description

- Added [Genmoji](https://genmoji.xyz) mention in the related tools section

Genmoji generates a suitable commit message associated with a fitting gitmoji using the openAI API, so would be interesting to have it mentioned on the gitmoji website itself.

## Linked issues

- https://github.com/carloscuesta/gitmoji/issues/1387