### PR TITLE
:bug: Text content does not match server-rendered HTML

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,8 +11,8 @@ If you would like to add a new emoji to gitmoji, fill the provided `ISSUE_TEMPLA
 1. Fork [this repository](https://github.com/carloscuesta/gitmoji/fork).
 2. Create a new branch with the feature name. (Eg: add-emoji-deploy, fix-website-header)
 3. Make your changes.
-4. Test you changes by running `yarn test`
-   - 4.1. If the snapshots are failing run `yarn test -u` and be sure that the new snapshots match your changes
+4. Test you changes by running `yarn turbo test`
+   - 4.1. If the snapshots are failing run `yarn turbo test -- -u` and be sure that the new snapshots match your changes
 5. Commit your changes. Don't forget to add a commit title with an emoji and a description.
 6. Push your changes.
 7. Submit your pull request.

--- a/packages/website/src/__tests__/__snapshots__/pages.spec.tsx.snap
+++ b/packages/website/src/__tests__/__snapshots__/pages.spec.tsx.snap
@@ -564,12 +564,6 @@ exports[`Pages Index should render the page 1`] = `
             type="search"
             value=""
           />
-          <kbd
-            className="kbd"
-          >
-            Ctrl
-             K
-          </kbd>
         </div>
         <div
           className="actionsContainer"

--- a/packages/website/src/components/GitmojiList/Toolbar/Kbd/index.tsx
+++ b/packages/website/src/components/GitmojiList/Toolbar/Kbd/index.tsx
@@ -1,0 +1,14 @@
+import styles from './styles.module.css'
+
+const isMacOs = () => {
+  return (
+    typeof window !== 'undefined' &&
+    window.navigator.platform.toUpperCase().includes('MAC')
+  )
+}
+
+const Kbd = () => {
+  return <kbd className={styles.kbd}>{isMacOs() ? '⌘' : 'Ctrl'} K</kbd>
+}
+
+export default Kbd

--- a/packages/website/src/components/GitmojiList/Toolbar/Kbd/styles.module.css
+++ b/packages/website/src/components/GitmojiList/Toolbar/Kbd/styles.module.css
@@ -1,0 +1,21 @@
+.kbd {
+  right: 0;
+  align-items: center;
+  border-radius: 3px;
+  border: solid 1px #999;
+  color: #595959;
+  display: flex;
+  font-family: system-ui;
+  margin-right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+}
+
+[data-theme='dark'] .kbd {
+  color: #b8b8b8;
+}
+
+@media (max-width: 568px) {
+  .kbd {
+    display: none;
+  }
+}

--- a/packages/website/src/components/GitmojiList/Toolbar/index.tsx
+++ b/packages/website/src/components/GitmojiList/Toolbar/index.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react'
+import dynamic from 'next/dynamic'
 
 import ListModeSelector from './ListModeSelector'
 import ThemeSelector from './ThemeSelector'
+const Kbd = dynamic(() => import('./Kbd'), { ssr: false })
 import styles from './styles.module.css'
 
 type Props = {
@@ -9,12 +11,6 @@ type Props = {
   searchInput?: string
   setIsListMode: (searchInput: boolean) => void
   setSearchInput: (searchInput: string) => void
-}
-
-const isMacOs = () => {
-  return typeof window === 'undefined'
-    ? true
-    : window.navigator.platform.toUpperCase().indexOf('MAC') >= 0
 }
 
 const Toolbar = (props: Props) => {
@@ -55,7 +51,7 @@ const Toolbar = (props: Props) => {
           value={props.searchInput}
         />
 
-        <kbd className={styles.kbd}>{isMacOs() ? '⌘' : 'Ctrl'} K</kbd>
+        <Kbd />
       </div>
 
       <div className={styles.actionsContainer}>

--- a/packages/website/src/components/GitmojiList/Toolbar/styles.module.css
+++ b/packages/website/src/components/GitmojiList/Toolbar/styles.module.css
@@ -41,24 +41,8 @@
   outline: none;
 }
 
-.kbd {
-  right: 0;
-  align-items: center;
-  border-radius: 3px;
-  border: solid 1px #999;
-  color: #595959;
-  display: flex;
-  font-family: system-ui;
-  margin-right: 0.5rem;
-  padding: 0.25rem 0.5rem;
-}
-
 [data-theme='dark'] .searchInput {
   color: var(--text);
-}
-
-[data-theme='dark'] .kbd {
-  color: #b8b8b8;
 }
 
 @media (max-width: 568px) {
@@ -70,9 +54,5 @@
   .container {
     flex-direction: column-reverse;
     align-items: stretch;
-  }
-
-  .kbd {
-    display: none;
   }
 }

--- a/packages/website/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.tsx.snap
+++ b/packages/website/src/components/GitmojiList/__tests__/__snapshots__/gitmojiList.spec.tsx.snap
@@ -360,12 +360,6 @@ exports[`GitmojiList when is not list mode should render the component 1`] = `
           type="search"
           value=""
         />
-        <kbd
-          className="kbd"
-        >
-          Ctrl
-           K
-        </kbd>
       </div>
       <div
         className="actionsContainer"


### PR DESCRIPTION
Fixes #1396 (or at least a part of it)

The issue there was that for non-macos users the client-side rendered content differed from server-side rendered content.

We now use a `useEffect` so React does not complain anymore about this.

I also updated `isMacOs` to return `false` by default.
