### PR TITLE
change twitter to twitter-x icon

### DIFF
--- a/packages/website/src/__tests__/__snapshots__/pages.spec.tsx.snap
+++ b/packages/website/src/__tests__/__snapshots__/pages.spec.tsx.snap
@@ -282,6 +282,17 @@ exports[`Pages App should render the page 1`] = `
         />
       </symbol>
       <symbol
+        id="icon-twitter-x"
+        viewBox="0 0 48 35"
+      >
+        <title>
+          twitter-x
+        </title>
+        <path
+          d="M12.91 5.477l14.813 19.882-14.907 16.164h3.356l13.05-14.152 10.544 14.152h11.418l-15.645-21L49.414 5.477H46.06l-12.02 13.035-9.71-13.035zm4.934 2.48h5.242L46.25 39.043h-5.246zm0 0"
+        />
+      </symbol>
+      <symbol
         id="icon-list"
         viewBox="0 0 512 512"
         x="0px"
@@ -417,13 +428,13 @@ exports[`Pages App should render the page 1`] = `
         target="_blank"
       >
         <svg
-          className="icon icon-twitter"
+          className="icon icon-twitter-x"
         >
           <use
-            xlinkHref="#icon-twitter"
+            xlinkHref="#icon-twitter-x"
           />
         </svg>
-        Tweet
+        Share
       </a>
     </div>
   </header>,

--- a/packages/website/src/components/Icon/__tests__/__snapshots__/icon.spec.tsx.snap
+++ b/packages/website/src/components/Icon/__tests__/__snapshots__/icon.spec.tsx.snap
@@ -102,6 +102,17 @@ exports[`Icon should match Definitions 1`] = `
       />
     </symbol>
     <symbol
+      id="icon-twitter-x"
+      viewBox="0 0 48 35"
+    >
+      <title>
+        twitter-x
+      </title>
+      <path
+        d="M12.91 5.477l14.813 19.882-14.907 16.164h3.356l13.05-14.152 10.544 14.152h11.418l-15.645-21L49.414 5.477H46.06l-12.02 13.035-9.71-13.035zm4.934 2.48h5.242L46.25 39.043h-5.246zm0 0"
+      />
+    </symbol>
+    <symbol
       id="icon-list"
       viewBox="0 0 512 512"
       x="0px"

--- a/packages/website/src/components/Icon/definitions.tsx
+++ b/packages/website/src/components/Icon/definitions.tsx
@@ -53,6 +53,10 @@ export const IconDefinitions = () => (
         </g>
         <circle cx="15.1" cy="24.9" r="2.5" fill="#3e4347" />
       </symbol>
+      <symbol id="icon-twitter-x" viewBox="0 0 48 35">
+        <title>twitter-x</title>
+        <path d="M12.91 5.477l14.813 19.882-14.907 16.164h3.356l13.05-14.152 10.544 14.152h11.418l-15.645-21L49.414 5.477H46.06l-12.02 13.035-9.71-13.035zm4.934 2.48h5.242L46.25 39.043h-5.246zm0 0"></path>
+      </symbol>
       <symbol id="icon-list" x="0px" y="0px" viewBox="0 0 512 512">
         <title>list</title>
         <path

--- a/packages/website/src/components/Layout/Header/index.tsx
+++ b/packages/website/src/components/Layout/Header/index.tsx
@@ -17,7 +17,7 @@ const Header = (props: Props) => (
         text="GitHub"
       />
       <Button
-        icon="twitter"
+        icon="twitter-x"
         link={
           'https://twitter.com/intent/tweet?text=gitmoji' +
           '%20%E2%80%93%20An%20%23emoji%20guide%20for%20your%20commit' +
@@ -25,7 +25,7 @@ const Header = (props: Props) => (
           '&url=https://gitmoji.dev'
         }
         target="_blank"
-        text="Tweet"
+        text="Share"
       />
     </div>
   </header>

--- a/packages/website/src/components/Layout/__tests__/__snapshots__/layout.spec.tsx.snap
+++ b/packages/website/src/components/Layout/__tests__/__snapshots__/layout.spec.tsx.snap
@@ -399,6 +399,17 @@ exports[`Layout should render the component 1`] = `
         />
       </symbol>
       <symbol
+        id="icon-twitter-x"
+        viewBox="0 0 48 35"
+      >
+        <title>
+          twitter-x
+        </title>
+        <path
+          d="M12.91 5.477l14.813 19.882-14.907 16.164h3.356l13.05-14.152 10.544 14.152h11.418l-15.645-21L49.414 5.477H46.06l-12.02 13.035-9.71-13.035zm4.934 2.48h5.242L46.25 39.043h-5.246zm0 0"
+        />
+      </symbol>
+      <symbol
         id="icon-list"
         viewBox="0 0 512 512"
         x="0px"
@@ -534,13 +545,13 @@ exports[`Layout should render the component 1`] = `
         target="_blank"
       >
         <svg
-          className="icon icon-twitter"
+          className="icon icon-twitter-x"
         >
           <use
-            xlinkHref="#icon-twitter"
+            xlinkHref="#icon-twitter-x"
           />
         </svg>
-        Tweet
+        Share
       </a>
     </div>
   </header>,


### PR DESCRIPTION
<!--
Please, before opening a PR, first open an issue as stated in the [contributing guidelines][1],
so we can talk about features and discuss implementations.

[1]: https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#contributing-to-gitmoji
-->

## Description

<!-- Explanation about your pull request, what changes you've made -->
After the rebranding of twitter to X by Elon Musk, it might be pertinent to update the "tweet" button. It does look a bit off and twitter still has more brand recognition than X, but I leave that up to the maintainers of gitmoji to pick what they prefer.  

![image](https://github.com/carloscuesta/gitmoji/assets/60617358/777adaa7-27a9-42f1-8601-79d20ff6b14f)

## Linked issues

https://github.com/carloscuesta/gitmoji/issues/1563