### PR TITLE
✨ Extend lock gitmoji to include privacy

### DIFF
--- a/.github/ISSUE_TEMPLATE/gitmoji-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/gitmoji-proposal.yml
@@ -50,7 +50,7 @@ body:
   - type: checkboxes
     id: emoji-what-how
     attributes:
-      label:  Does this emoji fall into the "how" or the "what" category?
+      label: Does this emoji fall into the "how" or the "what" category?
       description: |
         We are trying to always describe/categorize "what" has been done in a particular commit, not the "how" it was done (the exceptions being :poop: and :beers:).
 
@@ -59,7 +59,7 @@ body:
         | Examples of "what" commits                    | Examples of "how" commits                         |
         | --------------------------                    | -------------------------                         |
         | :white_check_mark: Add, update, or pass tests | :hankey: Write bad code that needs to be improved |
-        | :lock: Fix security issues                    | :beers: Write code drunkenly                      |
+        | :lock: Fix security or privacy issues         | :beers: Write code drunkenly                      |
         | :zap: Improve performance                     | :robot: Write an automated commit by a script     |
       options:
         - label: This proposal do **not** describe "how" a commit was made, but does in fact describe "what" is the contents of the commit about.
@@ -69,7 +69,7 @@ body:
   - type: textarea
     id: emoji-examples
     attributes:
-      label:  Examples
+      label: Examples
       description: Include some examples using this emoji.
       placeholder: Examples
     validations:

--- a/packages/gitmojis/src/gitmojis.json
+++ b/packages/gitmojis/src/gitmojis.json
@@ -93,7 +93,7 @@
       "emoji": "🔒️",
       "entity": "&#x1f512;",
       "code": ":lock:",
-      "description": "Fix security issues.",
+      "description": "Fix security or privacy issues.",
       "name": "lock",
       "semver": "patch"
     },

--- a/packages/website/src/__tests__/__snapshots__/pages.spec.tsx.snap
+++ b/packages/website/src/__tests__/__snapshots__/pages.spec.tsx.snap
@@ -1151,7 +1151,7 @@ exports[`Pages Index should render the page 1`] = `
             </code>
           </button>
           <p>
-            Fix security issues.
+            Fix security or privacy issues.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Extends 🔒 `:lock:` gitmoji to include security and privacy.

Closes #1445

---

<!--
Please, before opening a PR, first open an issue as stated in the [contributing guidelines][1],
so we can talk about features and discuss implementations.

[1]: https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#contributing-to-gitmoji
-->

## Description

<!-- Explanation about your pull request, what changes you've made -->

Extends 🔒 `:lock:` gitmoji to include security and privacy.

## Linked issues

#1445