### PR TITLE
♻️ Move `@vercel/analytics` to website as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "dev": "pnpm turbo --parallel dev"
   },
   "devDependencies": {
-    "@vercel/analytics": "^1.1.1",
     "husky": "^8.0.3",
     "lint-staged": "^14.0.1",
     "prettier": "3.0.3",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -20,6 +20,7 @@
     "@types/react-test-renderer": "^18.0.3",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
+    "@vercel/analytics": "^1.1.1",
     "clipboard": "^2.0.11",
     "eslint": "^8.48.0",
     "eslint-config-next": "^14.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      '@vercel/analytics':
-        specifier: ^1.1.1
-        version: 1.1.1
       husky:
         specifier: ^8.0.3
         version: 8.0.3
@@ -62,6 +59,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^6.9.1
         version: 6.9.1(eslint@8.48.0)(typescript@5.2.2)
+      '@vercel/analytics':
+        specifier: ^1.1.1
+        version: 1.1.1
       clipboard:
         specifier: ^2.0.11
         version: 2.0.11


### PR DESCRIPTION
## Description

👋 hey! I'm coming from https://www.shew.dev/monorepos/examples, just moved `@vercel/analytics` to the `packages/website` from the monorepo root. 😁👍 

