### PR TITLE
✨ Add "gitmoji_version" field to schema

### DIFF
--- a/packages/gitmojis/src/gitmojis.json
+++ b/packages/gitmojis/src/gitmojis.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://gitmoji.dev/api/gitmojis/schema",
+  "gitmoji_version": "3.14.0",
   "gitmojis": [
     {
       "emoji": "🎨",

--- a/packages/gitmojis/src/schema.json
+++ b/packages/gitmojis/src/schema.json
@@ -1,8 +1,11 @@
 {
   "type": "object",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "required": ["gitmojis"],
+  "required": ["gitmoji_version", "gitmojis"],
   "properties": {
+    "gitmoji_version": {
+      "type": "string"
+    },
     "gitmojis": {
       "type": "array",
       "minItems": 1,


### PR DESCRIPTION
<!--
Please, before opening a PR, first open an issue as stated in the [contributing guidelines][1],
so we can talk about features and discuss implementations.

[1]: https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#contributing-to-gitmoji
-->

## Description

I pipe gitmojis.json file to dmenu and it would be nice to have gitmoji version there as well, so I would know if I'm using outdated version quickly.

```bash
cat gitmojis.json | jq 'JQ magic' | wofi --show dmenu --prompt 'Search gitmoji...but what version hmmm'
```

After merge could be change to:
```bash
cat gitmojis.json | jq 'JQ magic' | wofi --show dmenu --prompt "Search gitmoji ($(cat gitmojis.json | jq -r '.gitmoji_version'))"
```