### PR TITLE
✨ Adds ✈️ for offline support

### DIFF
--- a/packages/gitmojis/src/gitmojis.json
+++ b/packages/gitmojis/src/gitmojis.json
@@ -584,6 +584,14 @@
       "description": "Add or update code related to validation.",
       "name": "safety-vest",
       "semver": null
+    },
+    {
+      "emoji": "✈️",
+      "entity": "&#x2708;",
+      "code": ":airplane:",
+      "description": "Improve offline support.",
+      "name": "airplane",
+      "semver": null
     }
   ]
 }

--- a/packages/website/src/__tests__/__snapshots__/pages.spec.tsx.snap
+++ b/packages/website/src/__tests__/__snapshots__/pages.spec.tsx.snap
@@ -4087,6 +4087,49 @@ exports[`Pages Index should render the page 1`] = `
         </div>
       </div>
     </article>
+    <article
+      className="emoji col-xs-12 col-sm-6 col-md-3"
+      style={
+        {
+          "--emojiColor": "#74d4ec",
+        }
+      }
+    >
+      <div
+        className="card "
+      >
+        <header
+          className="cardHeader"
+        >
+          <button
+            className="gitmoji-clipboard-emoji gitmoji"
+            data-clipboard-text="✈️"
+            type="button"
+          >
+            ✈️
+          </button>
+        </header>
+        <div
+          className="gitmojiInfo"
+        >
+          <button
+            className="gitmoji-clipboard-code gitmojiCode"
+            data-clipboard-text=":airplane:"
+            tabIndex={-1}
+            type="button"
+          >
+            <code>
+              <span>
+                :airplane:
+              </span>
+            </code>
+          </button>
+          <p>
+            Improve offline support.
+          </p>
+        </div>
+      </div>
+    </article>
   </div>
   <div
     id="_rht_toaster"

--- a/packages/website/src/components/GitmojiList/emojiColorsMap.ts
+++ b/packages/website/src/components/GitmojiList/emojiColorsMap.ts
@@ -74,4 +74,5 @@ export default {
   technologist: '#86B837',
   'money-with-wings': '#b3c0b1',
   thread: '#ffbe7b',
+  airplane: '#74d4ec',
 } as const


### PR DESCRIPTION
<!--
Please, before opening a PR, first open an issue as stated in the [contributing guidelines][1],
so we can talk about features and discuss implementations.

[1]: https://github.com/carloscuesta/gitmoji/blob/master/.github/CONTRIBUTING.md#contributing-to-gitmoji
-->

## Description

As discussed [here](https://github.com/carloscuesta/gitmoji/issues/1868), this PR adds the ✈️ emoji to signify changes related to offline support!

Also updates the snapshots for tests to pass ✅ 

## Linked issues

https://github.com/carloscuesta/gitmoji/issues/1868