### PR TITLE
💄 Make footer sticker

### DIFF
--- a/packages/website/src/components/Layout/Footer/styles.module.css
+++ b/packages/website/src/components/Layout/Footer/styles.module.css
@@ -2,6 +2,8 @@
   padding: 1.5em;
   background-color: var(--footerBackground);
   color: var(--textInSecondary);
+  position: sticky;
+  top: 100vh;
 }
 
 .footerNav {

--- a/packages/website/src/utils/theme/theme.css
+++ b/packages/website/src/utils/theme/theme.css
@@ -42,6 +42,11 @@
   color: var(--cardText);
 }
 
+html {
+  scrollbar-gutter: stable;
+  scrollbar-color: var(--secondary) var(--background);
+}
+
 html,
 body {
   background-color: var(--background);
@@ -61,6 +66,12 @@ body {
     'Droid Sans',
     'Helvetica Neue',
     sans-serif;
+}
+
+html,
+body,
+#__next {
+  height: 100%;
 }
 
 h1 {


### PR DESCRIPTION


## Description
When a wrong search query is entered, there isn’t enough content to fill the page, so the footer floats up in an ugly way.

This commit makes the footer sticky, so it always stays at the bottom, even if the page is short.

It also keeps the scrollbar gutter stable, so the layout doesn’t jump when the scrollbar appears or disappears.
<img width="3801" height="1998" alt="image" src="https://github.com/user-attachments/assets/28464495-8ef1-4c60-b166-7263f6ba4a77" />
