### PR TITLE
📝 Update gitmemoji related tool url to maintained repo

### DIFF
--- a/packages/website/src/app/related-tools/page.tsx
+++ b/packages/website/src/app/related-tools/page.tsx
@@ -18,7 +18,7 @@ const tools = [
   {
     name: 'gitmemoji',
     description: 'A game to learn gitmojis.',
-    link: 'https://github.com/ImBIOS/gitmemoji/',
+    link: 'https://github.com/Lezurex/gitmemoji/',
   },
   {
     name: 'gitmoji-browser-extension',


### PR DESCRIPTION
## Description
The currently linked repo of the gitmemoji game appears to be inactive. This commit updates the linked url to an up-to-date fork of the original repo. I forked the original gitmemoji project when it got archived and kept it up-to-date and running since.
