### PR TITLE
📝 Add gitoryx to related tools

### DIFF
--- a/packages/website/src/app/related-tools/page.tsx
+++ b/packages/website/src/app/related-tools/page.tsx
@@ -103,6 +103,12 @@ const tools = [
     description: 'A flow launcher plugin to search and copy gitmojis',
     link: 'https://github.com/tho-myr/Flow.Launcher.Plugin.Gitmoji_Plus',
   },
+  {
+    name: 'gitoryx',
+    description:
+      'A native Git GUI with a built-in gitmoji picker for macOS & Windows.',
+    link: 'https://www.gitoryx.com',
+  },
 ]
 
 export default function RelatedTools() {


### PR DESCRIPTION
## Description

Added [Gitoryx](https://www.gitoryx.com) to the related tools page.

Gitoryx is a native Git GUI for macOS & Windows with a built-in gitmoji picker in the commit panel, allowing developers to easily select and use gitmojis when writing commit messages.

## Linked issues

No one